### PR TITLE
Add Camping and Cuba to the list of web frameworks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Contributions are always welcome! Thanks to all [contributors](https://github.co
 * [Sinatra](http://www.sinatrarb.com)
 * [Padrino](http://www.padrinorb.com)
 * [Lotus](http://lotusrb.org)
+* [Camping](http://camping.io)
+* [Cuba](http://cuba.is)
 
 ## Web Servers
 


### PR DESCRIPTION
This pull request adds Camping and Cuba to the list of web frameworks. Though the are probably not as popular as Rails and Sinatra, they do have elements that I really like.
