### PR TITLE
Add Concurrent Ruby to list of concurrency libraries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ Contributions are always welcome! Thanks to all [contributors](https://github.co
 
 * [EventMachine](https://github.com/eventmachine/eventmachine) - An event-driven I/O and lightweight concurrency library for Ruby
 * [Celluloid](http://celluloid.io) - Actor-based concurrent object framework for Ruby
+* [Concurrent Ruby](https://github.com/ruby-concurrency/concurrent-ruby) -
+  Modern concurrency tools including agents, futures, promises, thread pools, supervisors, and more. Inspired by Erlang, Clojure, Scala, Go, Java, JavaScript, and classic concurrency patterns.  
 
 ## Core Extensions
 


### PR DESCRIPTION
The concurrent-ruby gem by @jdantonio should most definitely be on this list too.
