### PR TITLE
Add API Builder: ActiveModel::Serializers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 
 * [Grape](http://intridea.github.io/grape) - An opinionated micro-framework for creating REST-like APIs in Ruby
 * [Rails::API](https://github.com/rails-api/rails-api)
+* [ActiveModel::Serializers](https://github.com/rails-api/active_model_serializers) - JSON serialization of objects
 * [Crêpe](https://github.com/crepe/crepe) - The thin API stack
 * [jbuilder](https://github.com/rails/jbuilder) - Create JSON structures via a Builder-style DSL
 * [rabl](https://github.com/nesquena/rabl) - General ruby templating with json, bson, xml, plist and msgpack support


### PR DESCRIPTION
> `ActiveModel::Serializers` encapsulates the JSON serialization of objects. 
> Objects that respond to read_attribute_for_serialization 
> (including `ActiveModel` and `ActiveRecord` objects) are supported.
> 
> Serializers know about both a model and the `current_user`, so you can
> customize serialization based upon whether a user is authorized to see the
> content.
> 
> In short, **serializers replace hash-driven development with object-oriented
> development.**
