### PR TITLE
Add termit gem for Google Translate with speech synthesis in terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Thor](http://whatisthor.com) - A toolkit for building powerful command-line interfaces
 * [Commander](https://github.com/visionmedia/commander) - The complete solution for Ruby command-line executables
 * [Slop](https://github.com/leejarvis/slop) - Simple Lightweight Option Parsing
+* [Termit](https://github.com/pawurb/termit) - Google Translate with speech synthesis in your terminal
 
 ## Authentication
 


### PR DESCRIPTION
Hello. I would like to recommend the gem I made to be included in your list. It has been featured in Ruby Weekly 168 and I have received a lot of positive feedback about it so far.
