### PR TITLE
Add Lita to DevOps tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Vagrant](http://www.vagrantup.com) - Create and configure lightweight, reproducible, and portable development environments
 * [Chef](https://github.com/opscode/chef) - A systems integration framework, built to bring the benefits of configuration management to your entire infrastructure
 * [Mina](https://github.com/mina-deploy/mina) - Really fast deployer and server automation tool. 
+* [Lita](https://www.lita.io/) - ChatOps for Ruby: A pluggable chat bot framework usable with any chat service.
 
 ## Git Tools
 


### PR DESCRIPTION
This patch adds [Lita](https://www.lita.io/) to the DevOps Tools section.
