### PR TITLE
Clarify Rack and add Passenger

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 
 ## Web Servers
 
-* [Rack](http://rack.github.io) - A Ruby Webserver Interface
+* [Rack](http://rack.github.io) - A common Ruby web server interface. By itself, it's just a specification and utility library, but all Ruby web servers implement this interface
+* [Phusion Passenger](https://www.phusionpassenger.com) - Fast and robust web server and application server
 * [Unicorn](http://unicorn.bogomips.org) - Rack HTTP server for fast clients and Unix
 * [Thin](http://code.macournoyer.com/thin) - Tiny, fast & funny HTTP server
 * [Puma](https://github.com/puma/puma) - A modern, concurrent web server for Ruby


### PR DESCRIPTION
This pull request clarifies the position of Rack, and also adds Passenger. By itself, Rack is just a specification and utility library so a lot of people don't work with it directly. It's relevance lies mostly in the fact that all Ruby web servers implement this interface, so that web servers don't have to implement support for each Ruby framework separately.
