### PR TITLE
Add Misc: Virtus.

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Treetop](https://github.com/cjheath/treetop) - PEG (Parsing Expression Grammar) parser
 * [Yomu](https://github.com/Erol/yomu) - Read text and metadata from files and documents (.doc, .docx, .pages, .odt, .rtf, .pdf)
 * [AASM](https://github.com/aasm/aasm) - A library for adding finite state machines to Ruby classes
+* [Virtus](https://github.com/solnic/virtus) - Attributes on Steroids for Plain Old Ruby Objects
 
 # Resources
 


### PR DESCRIPTION
> This is a partial extraction of the DataMapper Property API with various modifications and improvements. The goal is to provide a common API for defining attributes on a model so all ORMs/ODMs could use it instead of reinventing the wheel all over again. It is also suitable for any other use case where you need to extend your ruby objects with attributes that require data-type coercions.
