### PR TITLE
Adding ruby-jmeter

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [RR](https://github.com/rr/rr) - A test double framework that features a rich selection of double techniques and a terse syntax
 * [Bacon](https://github.com/chneukirchen/bacon) - A small RSpec clone
 * [Spinach](https://github.com/codegram/spinach) - Spinach is a high-level BDD framework that leverages the expressive Gherkin language (used by Cucumber) to help you define executable specifications of your application or library's acceptance criteria.
+* [Ruby-JMeter](https://github.com/flood-io/ruby-jmeter) - A Ruby based DSL for building JMeter test plans 
 
 ## Web Frameworks
 


### PR DESCRIPTION
Ruby-JMeter is a Ruby based DSL for building JMeter load test plans
