### PR TITLE
Add Misc: FastAttributes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,6 +608,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Yomu](https://github.com/Erol/yomu) - Read text and metadata from files and documents (.doc, .docx, .pages, .odt, .rtf, .pdf)
 * [AASM](https://github.com/aasm/aasm) - A library for adding finite state machines to Ruby classes
 * [Virtus](https://github.com/solnic/virtus) - Attributes on Steroids for Plain Old Ruby Objects
+* [FastAttributes](https://github.com/applift/fast_attributes) - FastAttributes adds attributes with their types to the class
 
 # Resources
 


### PR DESCRIPTION
> There are already a lot of good and flexible gems which solve a similar problem, allowing attributes to be defined with their types, for example: virtus or attrio. However, the disadvantage of these gems is performance. So, the goal of fast_attributes is to provide a simple solution which is fast, understandable and extendable.
