### PR TITLE
Add Inch to "Documentation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [RDoc](https://github.com/rdoc/rdoc) - RDoc produces HTML and command-line documentation for Ruby projects
 * [YARD](http://yardoc.org) - YARD enables the user to generate consistent, usable documentation that can be exported to a number of formats very easily
 * [grape-swagger](https://github.com/tim-vandecasteele/grape-swagger) - Add swagger compliant documentation to your Grape API
+* [Inch](https://github.com/rrrene/inch) - Inch is a documentation measurement and evalutation tool for Ruby code, based on YARD
 
 ## Testing
 


### PR DESCRIPTION
This adds Inch, a little project of mine, to the list.

From the README:

> inch is a little bit like Code Climate, but for your inline code documentation (and not a webservice).
> 
> It is a command-line utility that suggests places in your codebase where documentation can be improved.
> 
> If there are no inline-docs yet, inch can tell you where to start.

What do you think?
