### PR TITLE
Add order_query

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 ## Pagination
 
 * [Kaminari](https://github.com/amatsuda/kaminari) - A Scope & Engine based, clean, powerful, customizable and sophisticated paginator for modern web app frameworks and ORMs
+* [order_query](https://github.com/glebm/order_query) - A keyset pagination library to find the next or previous record(s) relative to the current one efficiently, e.g. for infinite scroll.
 * [will_paginate](https://github.com/mislav/will_paginate) - A pagination library that integrates with Ruby on Rails, Sinatra, Merb, DataMapper and Sequel
 
 ## PDF


### PR DESCRIPTION
The [order_query](https://github.com/glebm/order_query) gem finds the next/previous record(s) relative to the current one efficiently using [keyset pagination](http://use-the-index-luke.com/no-offset).
