### PR TITLE
Add reference to Surrounded

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Light Service](https://github.com/adomokos/light-service) - Series of Actions with an emphasis on simplicity.
 * [Mutations](https://github.com/cypriss/mutations) - Compose your business logic into commands that sanitize and validate input.
 * [Responders](https://github.com/plataformatec/responders) -  A set of Rails responders to dry up your application.
+* [Surrounded](https://github.com/saturnflyer/surrounded) - Encapsulated related objects in a single system to add behavior during runtime. Extensible implementation of DCI.
 * [Trailblazer](https://github.com/apotonick/trailblazer) - Trailblazer is a thin layer on top of Rails. It gently enforces encapsulation, an intuitive code structure and gives you an object-oriented architecture.
 * [wisper](https://github.com/krisleech/wisper) - A micro library providing Ruby objects with Publish-Subscribe capabilities.
 


### PR DESCRIPTION
I actively use and maintain Surrounded to handle separating business logic from the objects that need it. It is well documented in the readme explanation and examples of use, description of implementation, and instruction on handling alternative behavior https://github.com/saturnflyer/surrounded/blob/master/README.md