### PR TITLE
Add Derailed Benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,7 +685,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 * [benchmark-ips](https://github.com/evanphx/benchmark-ips) - Provides iteration per second benchmarking for Ruby.
 * [bullet](https://github.com/flyerhzm/bullet) - Help to kill N+1 queries and unused eager loading.
-* [Derailed Benchmarks](https://github.com/schneems/derailed_benchmarks) - A series of things you can use to benchmark a Rails app.
+* [Derailed Benchmarks](https://github.com/schneems/derailed_benchmarks) - A series of things you can use to benchmark any Rack based app.
 * [Peek](https://github.com/peek/peek) - Visual status bar showing Rails performance.
 * [perftools.rb](https://github.com/tmm1/perftools.rb) - gperftools (formerly known as google-perftools) for Ruby code.
 * [rack-mini-profiler](https://github.com/MiniProfiler/rack-mini-profiler) - Profiler for your development and production Ruby rack apps.

--- a/README.md
+++ b/README.md
@@ -685,6 +685,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 * [benchmark-ips](https://github.com/evanphx/benchmark-ips) - Provides iteration per second benchmarking for Ruby.
 * [bullet](https://github.com/flyerhzm/bullet) - Help to kill N+1 queries and unused eager loading.
+* [Derailed Benchmarks](https://github.com/schneems/derailed_benchmarks) - A series of things you can use to benchmark a Rails app.
 * [Peek](https://github.com/peek/peek) - Visual status bar showing Rails performance.
 * [perftools.rb](https://github.com/tmm1/perftools.rb) - gperftools (formerly known as google-perftools) for Ruby code.
 * [rack-mini-profiler](https://github.com/MiniProfiler/rack-mini-profiler) - Profiler for your development and production Ruby rack apps.


### PR DESCRIPTION
Derailed benchmark is some sort of collection of other gems to perform a benchmark. I wasn't sure if it should fit here as it's focused on Rails, but you can also use with Rack so I gave it a shot :smile: 

```
url: https://github.com/schneems/derailed_benchmarks
description: Go faster, off the Rails - Benchmarks for your whole Rails app
```