### PR TITLE
Honeybadger is an error handler at heart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Errbit](http://errbit.github.io/errbit) - The open source, self-hosted error catcher.
 * [Exception Handler](https://github.com/richpeck/exception_handler) - Custom error pages.
 * [Exception Notification](https://github.com/smartinez87/exception_notification) - A set of notifiers for sending notifications when errors occur in a Rack/Rails application.
+* [Honeybadger](https://www.honeybadger.io/) - Exception, uptime, and performance monitoring for Ruby.
 * [Nesty](https://github.com/skorks/nesty) - Nested exceptions for Ruby.
 * [Raven Ruby](https://github.com/getsentry/raven-ruby) - Raven is a Ruby client for Sentry.
 
@@ -1023,7 +1024,6 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Gitlab CI](https://about.gitlab.com/gitlab-ci/) - Integrate with your GitLab to run tests for your projects.
 * [GitLab](https://about.gitlab.com) -  Open source software to collaborate on code.
 * [Hakiri](https://hakiri.io) - Ship Secure Ruby Apps.
-* [Honeybadger](https://www.honeybadger.io/) - Exception, uptime, and performance monitoring for Ruby.
 * [HoundCI](https://houndci.com) - Review your Ruby code for style guide violations.
 * [HuBoard](https://huboard.com) - Kanban board for GitHub issues.
 * [Inch CI](http://inch-ci.org/) - Documentation badges for Ruby projects.


### PR DESCRIPTION
Honeybadger is basically an error reporting mechanism similar to Airbrake. I have used both of these applications and both these applications' main objective is to capture and aggregate run time errors. In that aspect it is right to list Honeybadger under `Error handling` instead of the miscellaneous `Services and Apps` section.

Please check the website for proof: https://www.honeybadger.io/

![image](https://cloud.githubusercontent.com/assets/1298587/7838471/b25d4894-04aa-11e5-9f78-67caf23d7efe.png)
