### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -969,7 +969,6 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [twilio-ruby](https://github.com/twilio/twilio-ruby) - A module for using the Twilio REST API and generating valid TwiML.
 * [twitter](https://github.com/sferik/twitter) - A Ruby interface to the Twitter API.
 * [wikipedia](https://github.com/kenpratt/wikipedia-client) - Ruby client for the Wikipedia API.
-* [youtube_it](https://github.com/kylejginavan/youtube_it) - An object-oriented Ruby wrapper for the YouTube GData API.
 * [Yt](https://github.com/Fullscreen/yt) - An object-oriented Ruby client for YouTube API V3.
 
 ## Video


### PR DESCRIPTION
Removed `youtube_it` gem from the list as it only supports youtube api v2 which is deprecated and has been turned off on April 4th 2015. A better option is using 'yt' gem which supports the newest v3 api.