### PR TITLE
Add Semantic Logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Lograge](https://github.com/roidrage/lograge) - An attempt to tame Rails' default policy to log everything.
 * [MongoDB Logger](https://github.com/le0pard/mongodb_logger) - MongoDB logger for Rails.
 * [Scrolls](https://github.com/asenchi/scrolls) - Simple logging.
+* [Semantic Logger](https://github.com/reidmorrison/semantic_logger) - Scalable, next generation logging for Ruby.
 * [Yell](https://github.com/rudionrails/yell) - Your Extensible Logging Library.
 
 ## Machine Learning


### PR DESCRIPTION
The gem's website: https://reidmorrison.github.io/semantic_logger/index.html
RubyGems: https://rubygems.org/gems/semantic_logger

From the website: "Next generation logging system for Ruby to support highly concurrent, high throughput, low latency systems

Semantic Logger takes logging in Ruby to the next level by adding several new capabilities to the commonly used Logging API."

