### PR TITLE
Word to Markdown link added

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [kramdown](https://github.com/gettalong/kramdown) - Kramdown is yet-another-markdown-parser but fast, pure Ruby, using a strict syntax definition and supporting several common extensions.
 * [Maruku](https://github.com/bhollis/maruku) - A pure-Ruby Markdown-superset interpreter.
 * [Redcarpet](https://github.com/vmg/redcarpet) - A fast, safe and extensible Markdown to (X)HTML parser.
+* [word-to-markdown](https://github.com/benbalter/word-to-markdown) - Gem to convert Microsoft Word documents to Markdown.
 
 ## Misc
 


### PR DESCRIPTION
A Ruby gem to convert Microsoft Word documents to Markdown.

**Supports**

1. Paragraphs
2. Numbered lists
3. Unnumbered lists
4. Nested lists
5. Italic
6. Bold
7. Explicit headings (e.g., selected as "Heading 1" or "Heading 2")
8. Implicit headings (e.g., text with a larger font size relative to paragraph text)
9. Images
10. Tables
11. Hyperlinks