### PR TITLE
Add SciCom (https://github.com/rbotafogo/scicom)

### DIFF
--- a/README.md
+++ b/README.md
@@ -867,6 +867,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * Data analysis/structures
   * [daru](https://github.com/v0dro/daru) - A library for storage, analysis, manipulation and visualization of data in pure Ruby.
   * [Rgl](https://github.com/monora/rgl) - A framework for graph data structures and algorithms.
+  * [SciCom](https://github.com/rbotafogo/scicom) - Very tigh integration between R and Ruby, based on Renjin, for the JVM.
 * Numerical arrays
   * [NMatrix](https://github.com/sciruby/nmatrix) - Fast numerical linear algebra library for Ruby.
   * [NArray](https://github.com/masa16/narray) - N-dimensional Numerical Array for Ruby.


### PR DESCRIPTION
https://github.com/rbotafogo/scicom

A very tight integration between R and Ruby, based on Renjin, for the JVM.  Documentation can be found at: https://github.com/rbotafogo/scicom/wiki and a long description of SciCom as a replacement to S4 in: https://github.com/rbotafogo/scicom/wiki/A-(not-so)-Short-Introduction-to-SciCom,
