### PR TITLE
Add Hanna to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Documentation](https://github.com/adamcooke/documentation) - A Rails engine to provider the ability to add documentation to a Rails application.
 * [GitHub Changelog Generator](https://github.com/skywinder/github-changelog-generator) - Automatically generate change log from your tags, issues, labels and pull requests on GitHub.
 * [grape-swagger](https://github.com/ruby-grape/grape-swagger) - Add swagger compliant documentation to your Grape API.
+* [Hanna](https://github.com/rdoc/hanna-nouveau) - An RDoc formatter built with simplicity, beauty and ease of browsing in mind.
 * [Hologram](https://github.com/trulia/hologram) - A markdown based documentation system for style guides. It parses comments in your CSS and helps you turn them into a beautiful style guide.
 * [Inch](https://github.com/rrrene/inch) - Inch is a documentation measurement and evalutation tool for Ruby code, based on YARD.
 * [RDoc](https://github.com/rdoc/rdoc) - RDoc produces HTML and command-line documentation for Ruby projects.


### PR DESCRIPTION
[Hanna](https://github.com/rdoc/hanna-nouveau) is a better RDoc formatter with simplicity, beauty and ease of browsing in mind. Examples from Sequel's documentation:

* http://sequel.jeremyevans.net/rdoc/classes/Sequel/Dataset.html
* http://sequel.jeremyevans.net/rdoc/files/doc/active_record_rdoc.html