### PR TITLE
Add dry-rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Apotomo](https://github.com/apotonick/apotomo) - Based on Cells, Apotomo gives you widgets and encapsulation, bubbling events, AJAX page updates, rock-solid testing and more.
 * [Cells](https://github.com/apotonick/cells) - View Components for Rails.
 * [Decent Exposure](https://github.com/hashrocket/decent_exposure) - A helper for creating declarative interfaces in controllers.
+* [dry-rb](https://github.com/dry-rb) -  dry-rb is a collection of next-generation Ruby libraries, each intended to encapsulate a common task.
 * [Interactor](https://github.com/collectiveidea/interactor) - Interactor provides a common interface for performing complex interactions in a single request.
 * [Light Service](https://github.com/adomokos/light-service) - Series of Actions with an emphasis on simplicity.
 * [Mutations](https://github.com/cypriss/mutations) - Compose your business logic into commands that sanitize and validate input.


### PR DESCRIPTION
Motivation: dry-rb is a growing in popularity collection of libraries. A significant part of these libraries are well suited for working with ORM and persistence tools. But I found it a bit more fair to put them in Abstraction part of list as you can find very nice dependency injection containers among dry-rb libraries.

Also I've decided to add all of the libraries with one link to dry-rb organization as I think it will be a consistent approach according to my reflections(that these are toolkit for increasing abstraction level).