### PR TITLE
Add OctoLinker browser extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1129,6 +1129,7 @@ Online tools, services and APIs to simplify development.
 * [HoundCI](https://houndci.com) - Review your Ruby code for style guide violations.
 * [HuBoard](https://huboard.com) - Kanban board for GitHub issues.
 * [Inch CI](http://inch-ci.org/) - Documentation badges for Ruby projects.
+* [OctoLinker](https://github.com/OctoLinker/browser-extension) - Navigate through projects on GitHub.com efficiently with the OctoLinker browser extension.
 * [Omniref](https://www.omniref.com) - A comprehensive Ruby documentation site.
 * [PR Dashboard](http://prs.crowdint.com/) - Review open Pull Requests from your organizations and leave a "LGTM" comment.
 * [PullReview](https://pullreview.com) - Automated code review for Ruby and Rails - from style to security.


### PR DESCRIPTION
Navigate through projects on GitHub.com efficiently with the OctoLinker browser extension.

Most projects consist of many files and third party dependencies. Files are referencing other files and / or dependencies by language specific statements like include or require. Dependencies are most likely declared in a file called manifest e.g. package.json or Gemfile. The OctoLinker browser extension makes these references clickable. No more copy and search.

https://github.com/OctoLinker/browser-extension

## Require
![require](https://cloud.githubusercontent.com/assets/1393946/18116659/016a4972-6f4a-11e6-835a-4efc628bc4a0.gif)

## Gem support
![gem](https://cloud.githubusercontent.com/assets/1393946/18116660/01821188-6f4a-11e6-82ea-6076dfad75de.gif)