### PR TITLE
Add Syro to Web Frameworks list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1093,6 +1093,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Ruby on Rails](http://rubyonrails.org) - A web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
 * [Scorched](http://scorchedrb.com) - Light-weight, inheritable and composable web framework, inspired by Sinatra.
 * [Sinatra](http://www.sinatrarb.com) - Classy web-development dressed in a DSL.
+* [Syro](https://github.com/soveran/syro/) - Simple router for web applications.
 * [Volt](https://github.com/voltrb/volt) - A Ruby web framework where your ruby code runs on both the server and the client.
 
 ## Web Servers


### PR DESCRIPTION
Syro is a "Simple router for web applications." that handles basic routing similarly to [Sinatra](https://github.com/sinatra/sinatra). It's by the [same author](https://github.com/soveran) as [Cuba](https://github.com/soveran/cuba) and according to him:

> An initial idea was to release a new version of Cuba that broke backward compatibility, but in the end my friends suggested to release this as a separate library. In the future, some ideas of this library could be included in Cuba as well.

[Source](https://github.com/soveran/syro#trivia).