### PR TITLE
Social networking: Remove Forem, update link to Thredded

### DIFF
--- a/README.md
+++ b/README.md
@@ -948,10 +948,9 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 * [diaspora*](https://github.com/diaspora/diaspora) - A privacy aware, distributed, open source social network.
 * [Discourse](https://github.com/discourse/discourse) - A platform for community discussion. Free, open, simple.
-* [Forem](https://github.com/radar/forem) - Rails 3 and Rails 4 forum engine.
 * [Mailboxer](https://github.com/mailboxer/mailboxer) - A private message system for Rails applications.
 * [Social Shares](https://github.com/Timrael/social_shares) - A gem to check how many times url was shared in social networks.
-* [Thredded](https://github.com/thredded/thredded) - Rails 4.2+ forum/messageboard engine. Its goal is to be as simple and feature rich as possible.
+* [Thredded](https://thredded.org) - Rails 4.2+ forums/messageboards engine. Its goal is to be as simple and feature rich as possible.
 
 ## Spreadsheets and Documents
 


### PR DESCRIPTION
Forem is [no longer maintained](https://github.com/rubysherpas/forem/blob/fb37858a51cfc8fe2ccd113e61af42546091fd27/README.md#no-longer-maintained).

Thredded now has a [homepage](https://thredded.org).