### PR TITLE
Add jaro_winkler link

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,6 +911,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * Utilities
   * [smarter_csv](https://github.com/tilo/smarter_csv) - Ruby Gem for smarter importing of CSV Files as Array(s) of Hashes.
   * [algorithms](https://github.com/kanwei/algorithms) - Library with documentation on when to use a particular structure/algorithm.
+  * [jaro_winkler](https://github.com/tonytonyjan/jaro_winkler) - Ruby & C implementation of Jaro-Winkler distance algorithm which supports UTF-8 string.
 
 ## Search
 


### PR DESCRIPTION
Some remarkable points:

- The only one jaro_winkler gem with C extension that can handle UTF-8 string so far.
- Part of [did_you_mean](https://github.com/yuki24/did_you_mean/blob/62a666ccbc21ded6b471ba883b935050b890f809/Gemfile), which has become built-gem since Ruby 2.3.
- Part of [roma](https://github.com/roma/roma/blob/a0311401d4e3fe17e218523c0e154084b55ca2e8/roma.gemspec#L48)