### PR TITLE
Add Cliqr in CLI builder category

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 ## CLI Builder
 
 * [Clamp](https://github.com/mdub/clamp) - A command-line application framework.
+* [Cliqr](https://github.com/anshulverma/cliqr) - A lightweight framework to build a command line application in Ruby.
 * [Cocaine](https://github.com/thoughtbot/cocaine) - A small library for doing (command) lines.
 * [Commander](https://github.com/commander-rb/commander) - The complete solution for Ruby command-line executables.
 * [formatador](https://github.com/geemus/formatador) - STDOUT text formatting.


### PR DESCRIPTION
[Cliqr](https://github.com/anshulverma/cliqr) is a lightweight framework to build CLI applications in Ruby. Some notable things about it:

```
- Support for
  - inbuilt sub-shell
  - option and argument validation
  - help and version actions
  - banner builder
  - widgets
    - ask multi-choice question and select answer using arrow keys 
    - more widgets to be added..
- prints a lot of useful debugging information if developer makes an error setting it up
- well tested (100% code coverage)
- examples in the repo that replicate well known command line tools (vagrant, hbase etc.)
```