### PR TITLE
Update Sorcery to new org repo and added Rails 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [OmniAuth](https://github.com/intridea/omniauth) - A library that standardizes multi-provider authentication utilizing Rack middleware.
 * [Rodauth](https://github.com/jeremyevans/rodauth) - Authentication and account management framework for Rack applications.
 * [Shield](https://github.com/cyx/shield) - Authentication protocol for use in your routing and model context.
-* [Sorcery](https://github.com/NoamB/sorcery) - Magical Authentication for Rails 3 and 4.
+* [Sorcery](https://github.com/Sorcery/sorcery) - Magical Authentication for Rails 4, and Rails 5.
 * [warden](https://github.com/hassox/warden) - General Rack Authentication Framework.
 * OAuth:
   * [Doorkeeper](https://github.com/doorkeeper-gem/doorkeeper) - An OAuth2 provider for Rails.


### PR DESCRIPTION
We moved sorcery over to an org repo, and awesome ruby should reflect its new home.