### PR TITLE
remove upmin-admin-ruby: framework is no longer actively maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Faalis](http://faalis.io) - A Rails engine which provides a robust platform to develop web applications. It contains a very simple yet powerful admin/dashboard interface too.
 * [RailsAdmin](https://github.com/sferik/rails_admin) - A Rails engine that provides an easy-to-use interface for managing your data.
 * [Typus](https://github.com/typus/typus) - Ruby on Rails control panel to allow trusted users edit structured content.
-* [Upmin Admin](https://github.com/upmin/upmin-admin-ruby) - A framework for creating powerful Ruby on Rails admin backends with minimal effort.
 
 ## Analytics
 


### PR DESCRIPTION
Maintainers  suggest to use Administrate