### PR TITLE
Ruby5 last episode was on September 20th, 2016

### DIFF
--- a/README.md
+++ b/README.md
@@ -1175,7 +1175,6 @@ Where to discover new Ruby libraries, projects and trends.
 * [GitHub Trending](https://github.com/trending?l=ruby) - Find what repositories the GitHub community is most excited about today.
 * [Green Ruby News](http://greenruby.org) - A feed of fresh links of the week about ruby, javascript, webdev and devops.
 * [Open Source Rails](http://www.opensourcerails.com/) - A gallery of the best open source rack and Ruby on Rails web applications.
-* [Ruby5](http://ruby5.envylabs.com) - The latest news in the Ruby and Rails community.
 * [Ruby Bookmarks](https://github.com/dreikanter/ruby-bookmarks) - Ruby and Ruby on Rails bookmarks collection.
 * [RubyDaily](http://rubydaily.org) - Community driven news.
 * [RubyFlow](http://www.rubyflow.com) - Ruby Programming Community Link Blog.


### PR DESCRIPTION
Sadness, I know. They've decided not to continue the mini podcast.

