### PR TITLE
Add Module Linker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1156,6 +1156,7 @@ Online tools, services and APIs to simplify development.
 * [HoundCI](https://houndci.com) - Review your Ruby code for style guide violations.
 * [HuBoard](https://huboard.com) - Kanban board for GitHub issues.
 * [Inch CI](http://inch-ci.org/) - Documentation badges for Ruby projects.
+* [Module Linker](http://fiatjaf.alhur.es/module-linker/#/ruby) - A Chrome Extension that adds direct links to `require` statements right in GitHub source code.
 * [Nanobox](https://github.com/nanobox-io/nanobox) - A micro-PaaS (μPaaS) for creating consistent, isolated, Ruby environments deployable anywhere https://nanobox.io.
 * [OctoLinker](https://github.com/OctoLinker/browser-extension) - Navigate through projects on GitHub.com efficiently with the OctoLinker browser extension.
 * [PR Dashboard](http://prs.crowdint.com/) - Review open Pull Requests from your organizations and leave a "LGTM" comment.


### PR DESCRIPTION
Adds [Module Linker](http://fiatjaf.alhur.es/module-linker/#/ruby), a Chrome Extension that adds direct links to `require` statements right in GitHub source code. What the extension actually does is exemplified better in the following animated GIF:

![](http://fiatjaf.alhur.es/module-linker/screenshot/ruby-screencast.gif)