### PR TITLE
Add the iodine web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1128,6 +1128,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 ## Web Servers
 
 * [Goliath](https://github.com/postrank-labs/goliath) - A non-blocking Ruby web server framework.
+* [Iodine](https://github.com/boazsegev/iodine) - An non-blocking HTTP and Websocket web server optimized for Linux/BDS/macOS and Ruby MRI.
 * [Phusion Passenger](https://www.phusionpassenger.com) - Fast and robust web server and application server.
 * [Puma](https://github.com/puma/puma) - A modern, concurrent web server for Ruby.
 * [Rack](http://rack.github.io) - A common Ruby web server interface. By itself, it's just a specification and utility library, but all Ruby web servers implement this interface.


### PR DESCRIPTION
Thanks for maintaining this wonderful resource listing 👍🏻

I propose the addition of the iodine HTTP and Websocket server.

It's super fast and it's been here long enough for many of it's kinks to have been ironed out.

It's been tested with 20K active concurrent connections with good performance results and it supports native Websockets as well as HTTP.

It's optimized for (C)Ruby MRI, allowing many operations (network buffer management, IO bound tasks, timeout review, parsing etc') to run in true concurrency outside the GIL.

It maintains connection locks, preventing the same Websocket connection from having multiple `on_message` and `defer` events running at the same time.

I might be biased, but I think it's  as good as (if not better) than some of the web servers that were accepted to this amazing listing 👍🏻

P.S.

It should have probably qualify for the `WebSocket` as well... but I noticed there's a "one line at a time" requirement.