### PR TITLE
added Hyperloop to web frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1125,6 +1125,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Cuba](http://cuba.is) - A microframework for web development.
 * [Hobbit](https://github.com/patriciomacadden/hobbit) - A minimalistic microframework built on top of Rack.
 * [Hanami](http://hanamirb.org) - It aims to bring back Object Oriented Programming to web development, leveraging on a stable API, a minimal DSL, and plain objects.
+* [Hyperloop](http://ruby-hyperloop.io/) - A Complete Isomorphic Ruby Framework using React, Rails and Opal
 * [Padrino](http://www.padrinorb.com) - A full-stack ruby framework built upon Sinatra.
 * [Pakyow](http://pakyow.com/) - A framework for building modern web-apps in Ruby. It helps you build working software faster with a development process that remains friendly to both designers and developers.
 * [Ramaze](http://ramaze.net/) - A simple, light and modular open-source web application framework written in Ruby.


### PR DESCRIPTION
Ruby Hyperloop is an active and vibrant project (similar to Volt) - please add to your fantastic list. This project was previously known as 'reactrb' but has been renamed Hyperloop.

Project website: http://ruby-hyperloop.io/
Github here: https://github.com/ruby-hyperloop

Thank you