### PR TITLE
Removed "Wrong" as it is no longer maintained (#719)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1074,7 +1074,6 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
   * [timecop](https://github.com/travisjeffery/timecop) - Provides "time travel" and "time freezing" capabilities, making it dead simple to test time-dependent code.
   * [vcr](https://github.com/vcr/vcr) - Record your test suite's HTTP interactions and replay them during future test runs for fast, deterministic, accurate tests.
   * [Zapata](https://github.com/Nedomas/zapata) - Who has time to write tests? This is a revolutionary tool to make them write themselves.
-  * [Wrong](https://github.com/sconover/wrong) - Wrong provides a general assert method that takes a predicate block. Assertion failure messages are rich in detail.
 
 ## Third-party APIs
 


### PR DESCRIPTION
As proposed in ticket #719, the "Wrong" project is no longer maintained, and should be removed.