### PR TITLE
Add batch-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
   * [Presentation Programs](#presentation-programs)
   * [Process Monitoring](#process-monitoring)
   * [Processes and Threads](#processes-and-threads)
-  * [Profiler](#profiler)
+  * [Profiler and Optimization](#profiler-and-optimization)
   * [Queue](#queue)
   * [Rails Application Generators](#rails-application-generators)
   * [Robotics](#robotics)
@@ -851,8 +851,9 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [posix-spawn](https://github.com/rtomayko/posix-spawn) - Fast Process::spawn for Rubys >= 1.8.7 based on the posix_spawn() system interfaces.
 
-## Profiler
+## Profiler and Optimization
 
+* [batch-loader](https://github.com/exaspark/batch-loader) – A generic lazy batching mechanism to avoid N+1 DB queries, HTTP queries, etc.
 * [benchmark-ips](https://github.com/evanphx/benchmark-ips) - Provides iteration per second benchmarking for Ruby.
 * [bullet](https://github.com/flyerhzm/bullet) - Help to kill N+1 queries and unused eager loading.
 * [Derailed Benchmarks](https://github.com/schneems/derailed_benchmarks) - A series of things you can use to benchmark any Rack based app.


### PR DESCRIPTION
Hi!

I created a new gem called [batch-loader](https://github.com/exaspark/batch-loader) which helps to avoid N+1 DB queries, HTTP requests, etc. In addition to the detailed description and some ASCII art in the [README](https://github.com/exaspark/batch-loader) I also created a small presentation. I'm using the [slides](https://speakerdeck.com/exaspark/batching-the-powerful-way-to-solve-n-plus-1-queries-every-rubyist-should-know) to describe to my internal team why the gem was created and how we can use it.

The gem can be used with any Ruby code, not only with GraphQL. In fact, we're using it with RESTful APIs on production. So, I was thinking about adding it to another category, the closest one could be `Data Processing and ETL`. But I decided to leave it in `GraphQL` for now, since it's not about ETL.

Would be glad to get your feedback. Whether it should be in `GraphQL` (it's fine for me), in some other existing categories or it's better to create a new one.