### PR TITLE
Added link to Rails Starter Template to Rails Application Generators …

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,6 +892,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Hobo](https://github.com/Hobo/hobo) - The web app builder for Rails.
 * [orats](https://github.com/nickjj/orats) - Opinionated rails application templates.
 * [Rails Composer](https://github.com/RailsApps/rails-composer) - The Rails generator on steroids for starter apps.
+* [Rails Starter Template](https://github.com/professorNim/rails_starter_template) - Yet another opinionated Rails starter template, designed to get you up and running in no time.
 * [Raygun](https://github.com/carbonfive/raygun) - Builds applications with the common customization stuff already done.
 * [Suspenders](https://github.com/thoughtbot/suspenders) - Suspenders is the base Rails application used at thoughtbot.
 


### PR DESCRIPTION
# Rails Application Generators

## Project

Rails Starter Template - [https://github.com/professorNim/rails_starter_template](https://github.com/professorNim/rails_starter_template)

## What is this Ruby project?

Yet another opinionated Rails starter template, designed to get you up and running in no time. Pre-configured to allow CI integration with CircleCI, auto-deployment to Heroku, and quality metrics by Code Climate.

Application Specific Gems:

- autoprefixer-rails
- bcrypt
- bootstrap-sass
- font-awesome-rails
- high_voltage
- jquery-rails
- kaminari

Development & testing gems:

- better_errors
- binding-of-caller
- byebug
- faker
- simplecov
- sqlite3
- minitest-reporters
- rails-controller-testing

Production gems:

- passenger
- pg

## What are the main difference between this Ruby project and similar ones?

Unlike Rails Composer which seems to be an all inclusive Rails template, allowing users to choose from a wide array of options, this template project aims to be more opinionated by making choices for users and allowing them to make changes later. A complete front end with authentication, authorization, account confirmation, and password recovery is included without using the bloat of an third-party gem like devise. Nothing against devise, it has it's uses, but adds, in my opinion, unnecessary complexity to applications.

Additionally, out of the box, this template creates an application that has 100% test coverage, scores a 4.0 GPA on Code Climate, includes dotfiles for use on CircleCI, and conforms to the [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide).