### PR TITLE
Added Git Cop gem for keeping a clean Git history.

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [git-spelunk](https://github.com/osheroff/git-spelunk) - Dig through git blame history.
 * [git-up](https://github.com/aanand/git-up) - Fetch and rebase all locally-tracked remote branches.
 * [git-whence](https://github.com/grosser/git-whence) - Find which merge a commit came from.
+* [Git Cop](https://github.com/bkuhlmann/git-cop) - Enforces consistent Git commits.
 * [Overcommit](https://github.com/brigade/overcommit) - A fully configurable and extendable Git hook manager.
 * [Rugged](https://github.com/libgit2/rugged) - Ruby bindings to libgit2.
 


### PR DESCRIPTION
## Project

[Git Cop](https://github.com/bkuhlmann/git-cop)

## What is this Ruby project?

- Enforces a [Git Rebase Workflow](http://www.bitsnbites.eu/a-tidy-linear-git-history).
- Enforces a clean and consistent Git commit history.
- Provides Continuous Integration (CI) build server support.
- Provides Git Hook support for local use.
- Provides a customizable suite of style cops.

## What are the main difference between this Ruby project and similar ones?

The only comparable gem in the current list is Overcommit. That said, Git Cop is purely focused on Git commits, hooks, and continous integration. It doesn't try deal with additional tooling like Overcommit does. If it helps, think of Git Cop to Git as Rubocop is to Ruby.

If you care about your project history (especially maintaining legacy code), this gem is highly recommended.