### PR TITLE
Add table_print gem to CLI Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Pastel](https://github.com/peter-murach/pastel) - Terminal output styling with intuitive and clean API.
 * [Ru](https://github.com/tombenner/ru) - Ruby in your shell.
 * [Ruby/Progressbar](https://github.com/jfelchner/ruby-progressbar) - The most flexible text progress bar library for Ruby.
+* [TablePrint](https://github.com/arches/table_print) - Slice your data from multiple DB tables into a single CLI view.
 * [Terminal Table](https://github.com/tj/terminal-table) - Ruby ASCII Table Generator, simple and feature rich.
 * [Tmuxinator](https://github.com/tmuxinator/tmuxinator) - Create and manage complex tmux sessions easily.
 


### PR DESCRIPTION
## Project

TablePrint - [http://tableprintgem.com](http://tableprintgem.com)

## What is this Ruby project?

TablePrint shows objects in nicely formatted columns for easy reading. It even lets you combine multiple DB tables into a single CLI view, contextualizing data across tables. It's incredibly flexible, yet simple, making it easy to see exactly the data you care about.

## What are the main difference between this Ruby project and similar ones?

Perhaps you're wondering how table_print is different from some of your favorite IRB tools.

**terminal-table:**  An lower-level interface for turning arrays into tables.  TablePrint also displays tables, but the basic interaction is about your domain objects.  Much of the power of TablePrint is in the collection and combination of data, and the flexibility to see exactly the data you care about.  While terminal-table exposes an API for creating arbitrary tables and doesn't delve into where the data comes from, TablePrint exposes an API focused on the collection of data.

**awesome_print:** It is awesome, but it's geared toward inspecting individual objects or small groups of objects. table_print makes it easy to scan a column across groups of objects and notice patterns. I like to think of them as complementary.

**hirb:** It's a "view framework" that lets you navigate through your objects. It's geared toward browsing through a lot of data without much typing, and it supports a ton of different formats. But that comes with some heavy overhead around customization, and I have a difficult time creating the views I want to see - especially since what I want to see is constantly changing. table_print makes it easy to specify exactly what you want to see.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:, ...) and comments to express your feelings.