### PR TITLE
Add Docile

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Apotomo](https://github.com/apotonick/apotomo) - Based on Cells, Apotomo gives you widgets and encapsulation, bubbling events, AJAX page updates, rock-solid testing and more.
 * [Cells](https://github.com/apotonick/cells) - View Components for Rails.
 * [Decent Exposure](https://github.com/hashrocket/decent_exposure) - A helper for creating declarative interfaces in controllers.
+* [Docile](https://github.com/ms-ati/docile) - A tiny library that lets you map a DSL (domain specific language) to your Ruby objects in a snap.
 * [dry-rb](https://github.com/dry-rb) -  dry-rb is a collection of next-generation Ruby libraries, each intended to encapsulate a common task.
 * [Interactor](https://github.com/collectiveidea/interactor) - Interactor provides a common interface for performing complex interactions in a single request.
 * [Light Service](https://github.com/adomokos/light-service) - Series of Actions with an emphasis on simplicity.


### PR DESCRIPTION
**Thanks for contributing to Awesome Ruby! Please take a look at the [contribution guidelines and quality standard](https://github.com/markets/awesome-ruby/blob/master/CONTRIBUTING.md) first.**

## Project

[Docile](https://github.com/ms-ati/docile)

## What is this Ruby project?

A tiny library that lets you map a DSL (domain specific language) to your Ruby objects in a snap.

## What are the main difference between this Ruby project and similar ones?

I'm not aware of any other libraries that fill the same niche as Docile. It was written to extract the common patterns around usage of chained contexts for `instance_exec` or `instance_eval` from ad-hoc DSL code in various libraries. The goal is to have a common, community-maintained implementation of these patterns that avoids the common errors observed in the wild, such as local variables from the host object being unavailable to the code in the given block.

This library is fairly widely used as a dependency for other projects to implement their own configuration DSLs, with [SimpleCov](https://rubygems.org/gems/simplecov) probably being the most notable.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:, ...) and comments to express your feelings.