### PR TITLE
Add mac-wifi to CLI Utilities section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,6 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 
 * [colorls](https://github.com/athityakumar/colorls) - Beautifies the `ls` command, with color and font-awesome icons.
 * [formatador](https://github.com/geemus/formatador) - STDOUT text formatting.
-* [mac-wifi](https://github.com/keithrbennett/macwifi) -  A command line tool to manage Mac wifi, including an interactive shell.
 * [Paint](https://github.com/janlelis/paint) - Simple and fast way to set ANSI terminal colors.
 * [Pastel](https://github.com/peter-murach/pastel) - Terminal output styling with intuitive and clean API.
 * [Ru](https://github.com/tombenner/ru) - Ruby in your shell.
@@ -693,7 +692,6 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [play ►](https://github.com/play/play) - Your company's dj.
 * [PluggableJs](https://github.com/peresleguine/pluggable_js) - Page-specific javascript for Rails applications with the ability of passing data from a controller.
 * [QR-code](https://github.com/whomwah/rqrcode) - A Ruby library that encodes QR Codes
-* [RubyDNS](https://github.com/ioquatix/rubydns) - A high-performance DNS server which can be easily integrated into other projects or used as a stand-alone daemon.
 * [Ruby Operators](http://ruby-operators.herokuapp.com/) - A webpage showing awesome names for different Ruby operators.
 
 ## Mobile Development
@@ -734,6 +732,11 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Gretel](https://github.com/lassebunk/gretel) - A Ruby on Rails plugin that makes it easy yet flexible to create breadcrumbs.
 * [loaf](https://github.com/peter-murach/loaf) - Manages and displays breadcrumb trails in Rails app - lean & mean.
 * [Simple Navigation](https://github.com/codeplant/simple-navigation) - A ruby gem for creating navigation (html list, link list or breadcrumbs with multiple levels) for your Rails 2, 3 & 4, Sinatra or Padrino.
+
+## Networking
+
+* [mac-wifi](https://github.com/keithrbennett/macwifi) -  A command line tool to manage Mac wifi, including an interactive shell.
+* [RubyDNS](https://github.com/ioquatix/rubydns) - A high-performance DNS server which can be easily integrated into other projects or used as a stand-alone daemon.
 
 ## ORM/ODM
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 
 * [colorls](https://github.com/athityakumar/colorls) - Beautifies the `ls` command, with color and font-awesome icons.
 * [formatador](https://github.com/geemus/formatador) - STDOUT text formatting.
+* [mac-wifi](https://github.com/keithrbennett/macwifi) -  A command line tool to manage Mac wifi, including an interactive shell.
 * [Paint](https://github.com/janlelis/paint) - Simple and fast way to set ANSI terminal colors.
 * [Pastel](https://github.com/peter-murach/pastel) - Terminal output styling with intuitive and clean API.
 * [Ru](https://github.com/tombenner/ru) - Ruby in your shell.


### PR DESCRIPTION

## mac-wifi

[mac-wifi](https://github.com/keithrbennett/macwifi)

## What is this Ruby project?
The `mac-wifi` script installed by this gem (or otherwise copied) enables the query and management of wifi configuration and environment on a Mac. The code encapsulates the Mac OS specific logic in a minimal class to more easily add support for other operating systems, but as of now, only Mac OS is supported. (Feel free to add an OS!)

It can be run in single-command or interactive mode. Interactive mode uses the `pry` gem, providing an interface familiar to Rubyists and other [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop) users.

It is not necessary to download this repo or even install this gem; the `bin/mac-wifi` script file is all you need to run the application.


### Usage

Available commands can be seen by using the `h` (or `help`) option. Here is its
output at the time of this writing:

```
➜  mac-wifi git:(master) ✗   ./mac-wifi h

Available commands are:

ci                      - connected to Internet (not just wifi on)?
co[nnect] network-name  - turns wifi on, connects to network-name
cy[cle]                 - turns wifi off, then on, preserving network selection
d[isconnect]            - disconnects from current network, does not turn off wifi
h[elp]                  - prints this help
i[nfo]                  - prints wifi-related information
lsp[referred]           - lists preferred (not necessarily available) networks
lsa[vailable]           - lists available networks
n[etwork_name]          - name (SSID) of currently connected network
on                      - turns wifi on
of[f]                   - turns wifi off
pa[ssword] network-name - shows password for preferred network-name
q[uit]                  - exits this program (interactive shell mode only)
r[m] network-name       - removes network-name from the preferred networks list
s[hell]                 - opens an interactive pry shell (command line only)
t[ill]                  - (experimental!) returns when the desired Internet connection state is true. Options:
                          'on'/:on or 'off'/:off
                          wait interval, in seconds (optional, defaults to 0.5 seconds)
w[ifion]                - is the wifi on?
x[it]                   - exits this program (interactive shell mode only)

When in interactive shell mode:
    * use quotes for string parameters such as method names.
    * for pry commands, use prefix `%`.
```

## What are the main difference between this Ruby project and similar ones?

I am not aware of any similar utilities. This script uses several Mac OS command line utilities which could always be called directly instead of using this script. However, this script greatly simplifies these tasks, eliminating the need to know the various commands and their options, adding functionality, and enabling smoother implementation of compound commands.

----
Please help us to maintain this collection by using reactions (:+1:, :-1:, ...) and comments to express your feelings.