### PR TITLE
Add MicroMachine to "State Machines" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1013,6 +1013,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 * [AASM](https://github.com/aasm/aasm) - State machines for Ruby classes (plain Ruby, Rails Active Record, Mongoid).
 * [FiniteMachine](https://github.com/peter-murach/finite_machine) - A plain Ruby state machine with a straightforward and expressive syntax.
+* [MicroMachine](https://github.com/soveran/micromachine) - A minimal finite state machine implementation in less than 50 lines of code.
 * [simple_states](https://github.com/svenfuchs/simple_states) - A super-slim statemachine-like support library.
 * [Statesman](https://github.com/gocardless/statesman) - A statesmanlike state machine library.
 * [state_machines](https://github.com/state-machines/state_machines) - Adds support for creating state machines for attributes on any Ruby class.


### PR DESCRIPTION
## Project

[MicroMachine](https://github.com/soveran/micromachine)

## What is this Ruby project?

A small, simple finite state machine implementation.

## What are the main difference between this Ruby project and similar ones?

I think the README lays it out pretty simply:

> There are many finite state machine implementations for Ruby, and they all provide a nice DSL for declaring events, exceptions, callbacks, and all kinds of niceties in general.
>
> But if all you want is a finite state machine, look no further: this has less than 50 lines of code and provides everything a finite state machine must have, and nothing more.