### PR TITLE
Add Dnsruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Clipboard](https://github.com/janlelis/clipboard) - Access to the system clipboard on Linux, MacOS and Windows.
 * [Device Detector](https://github.com/podigee/device_detector) - A precise and fast user agent parser and device detector, backed by the largest and most up-to-date user agent database.
 * [Diffy](https://github.com/samg/diffy) - Easy Diffing With Ruby.
+* [Dnsruby](https://github.com/alexdalitz/dnsruby) -  A complete client side DNS library and recursive resolver, including DNSSEC support
 * [Foreman](https://github.com/ddollar/foreman) - Manage Procfile-based applications.
 * [Gollum](https://github.com/gollum/gollum) - A simple, Git-powered wiki with a sweet API and local frontend.
 * [gon](https://github.com/gazay/gon) - If you need to send some data to your js files and you don't want to do this with long way through views and parsing - use gon.


### PR DESCRIPTION
## Project

[dnsruby](https://github.com/alexdalitz/dnsruby)

## What is this Ruby project?

(From @alexdalitz, the author:)

A complete client side DNS library and recursive resolver, including DNSSEC support.

## What are the main difference between this Ruby project and similar ones?

(From @alexdalitz, the author:)

`dnsruby` differs from `rubydns` because `dnsruby` is a _client_ side library, whereas `rubydns` allows a dns _server_ to be written using `celluloid`.

There are other client-side libraries (`pnet-dns`, which I wrote before `dnsruby`, and also `net-dns`) - but they offer a small subset of the functionality of `dnsruby`. `net-dns` does not even implement the full set of RR types.

(Other than the above mentioned, we don't know of any similar gems. - KB)


---

Please help us to maintain this collection by using reactions (:+1:, :-1:, ...) and comments to express your feelings.