### PR TITLE
Add jquery-rails-cdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Emoji](https://github.com/wpeterson/emoji) - Exposes the Phantom Open Emoji library unicode/image assets and APIs for working with them.
 * [Less Rails](https://github.com/metaskills/less-rails) - The dynamic stylesheet language for the Rails asset pipeline.
 * [Less](https://github.com/cowboyd/less.rb) - Leaner CSS, in your browser or Ruby.
+* [jquery-rails-cdn](https://github.com/kenn/jquery-rails-cdn) - Add CDN support to jquery-rails
 * [Rails Assets](https://rails-assets.org) - Bundler to Bower proxy.
 * [Sass](http://sass-lang.com) - Sass makes CSS fun again.
 * [Sprockets](https://github.com/sstephenson/sprockets) - Rack-based asset packaging system.


### PR DESCRIPTION
## Project

[jquery-rails-cdn](https://github.com/kenn/jquery-rails-cdn)

## What is this Ruby project?

Add CDN support to jquery-rails

## What are the main difference between this Ruby project and similar ones?

jquery-rails serves jquery from your own server. jquery-rails-cdn serves it from common CDNs, which provides a number of benefits.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:, ...) and comments to express your feelings.