### PR TITLE
Add redis-classy

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,6 +752,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [NoBrainer](https://github.com/nviennot/nobrainer/) - A RethinkDB ORM for Ruby
 * [Ohm](https://github.com/soveran/ohm) - Object-hash mapping library for Redis.
 * [Perpetuity](https://github.com/jgaskins/perpetuity) - Persistence gem for Ruby objects using the Data Mapper pattern.
+* [redis-classy](https://github.com/kenn/redis-classy) - Class-style namespace prefixing for Redis
 * [Redis-Objects](https://github.com/nateware/redis-objects) - Redis Objects provides a Rubyish interface to Redis, by mapping Redis data types to Ruby objects, via a thin layer over the redis gem.
 * [ROM](https://github.com/rom-rb/rom) - Ruby Object Mapper (ROM) is an experimental Ruby library with the goal to provide powerful object mapping capabilities without limiting the full power of your datastore.
 * [Sequel](https://github.com/jeremyevans/sequel) - Sequel is a simple, flexible, and powerful SQL database access toolkit for Ruby.


### PR DESCRIPTION
## Project

[redis-classy](https://github.com/kenn/redis-classy)

## What is this Ruby project?

Class-style namespace prefixing for Redis.

## What are the main difference between this Ruby project and similar ones?

All non-trivial projects that use Redis at an application level require a solid namespacing strategy. redis-classy is a very simple concept and implementation that follows the convention-over-configuration philosophy.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:, ...) and comments to express your feelings.