### PR TITLE
Add EnumAccessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,6 +804,8 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
   * [Awesome Nested Set](https://github.com/collectiveidea/awesome_nested_set) - Awesome Nested Set is an implementation of the nested set pattern for ActiveRecord models.
   * [Closure Tree](https://github.com/mceachen/closure_tree) - Easily and efficiently make your ActiveRecord models support hierarchies using a Closure Table.
   * [Mongoid Tree](https://github.com/benedikt/mongoid-tree) - A tree structure for Mongoid documents using the materialized path pattern.
+* Type
+  * [EnumAccessor](https://github.com/kenn/enum_accessor) - Simple enum fields for ActiveRecord
 
 ## Package Management
 


### PR DESCRIPTION
## Project

[EnumAccessor](https://github.com/kenn/enum_accessor)

## What is this Ruby project?

Simple enum fields for ActiveRecord.

## What are the main difference between this Ruby project and similar ones?

Rails 4.1's official implementation came out with a design flaw. This gem does not have such crufts, and also supports a lot more features like validation, where-scoping, translation and forms with even shorter code base.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:, ...) and comments to express your feelings.