### PR TITLE
Add Dumper for database backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1179,6 +1179,7 @@ Online tools, services and APIs to simplify development.
 * [Codacy](https://www.codacy.com) - Automated Code Review for Ruby, Rails, JS, PHP, Python etc. Security, Coverage & Quality.
 * [CodeClimate](https://codeclimate.com) - Quality & security analysis for Ruby on Rails and Javascript.
 * [deppbot](https://www.deppbot.com) - Automated Security and Dependency Updates.
+* [Dumper](https://dumper.io) - Database backup to S3
 * [Gemnasium](https://gemnasium.com) - Monitor your project dependencies and alert you about updates and security vulnerabilities.
 * [GitHub](https://github.com) - Powerful collaboration, code review, and code management for open source and private projects.
 * [Gitlab CI](https://about.gitlab.com/gitlab-ci/) - Integrate with your GitLab to run tests for your projects.


### PR DESCRIPTION
## Project

[Dumper](https://dumper.io)

## What is this Ruby project?

Database backup to the cloud.

## What are the main difference between this Ruby project and similar ones?

It just works as a gem - no need to setup cron, zero admin task on the server.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:, ...) and comments to express your feelings.