### PR TITLE
Add Sym — a time-saving symmetric encryption gem based on OpenSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 ## Encryption
 
 * [RbNaCl](https://github.com/cryptosphere/rbnacl) - Ruby binding to the Networking and Cryptography (NaCl) library.
+* [Sym](https://github.com/kigster/sym) - A time-saving symmetric encryption gem based on OpenSSL that uses 256bit (password-encrypted) keys. Read the key from STDIN, a file, ENV or, on a Mac: OS-X Keychain.
 * [Symmetric Encryption](http://rocketjob.github.io/symmetric-encryption/) - Transparently encrypt ActiveRecord, Mongoid, and MongoMapper attributes. Encrypt passwords in configuration files. Encrypt entire files at rest.
 * [Themis](https://github.com/cossacklabs/themis) - crypto library for painless data security, providing symmetric and asymmetric encryption, secure sockets with forward secrecy, for mobile and server platforms.
 


### PR DESCRIPTION
**Thanks for contributing to Awesome Ruby! Please take a look at the [contribution guidelines and quality standard](https://github.com/markets/awesome-ruby/blob/master/CONTRIBUTING.md) first.**

## [Sym](https://github.com/kigster/sym)

 * Sym — Symmetric Encryption made easy
 * [https://github.com/kigster/sym](https://github.com/kigster/sym)

## What is this Ruby project?

[Sym](https://github.com/kigster/sym) is an open source command line utility and a Ruby API which makes it very easy to add reliable encryption and decryption of sensitive data to an application or a project written in any language.


## What are the main difference between this Ruby project and similar ones?

* Unlike many existing encryption tools, sym focuses on narrowing the gap between convenience and security, by offering enhanced usability and a streamlined ruby API and a CLI. The primary goal of the library is to make encryption very easy and transparent.

* Sym uses the Symmetric Encryption algorithm. This means that the same key is used to encrypt and decrypt data. In addition to the key, the encryption uses a randomized IV vector, which is automatically generated per each encryption and serialized with the data. Result of encryption is zlib-compressed, and base64 encoded, to be suitable for storage as string. The generated keys are also base64-encoded for convenience.

* Finally, the library offers encryption using any regular password, and in particular supports password-protected encryption keys. Automatic key detection algorithm attempts to resolve a provided key as a filename, an environment variable name, an OS-X Keychain password entry name, a key itself, or a default key file.

#### Encryption Features

 * Sym uses the same strong encryption as the US Government:
   * the Cipher `AES-256-CBC`
   * 256-bit private key, that
     *  can be generated and is a *base64-encoded* string about 45 characters long. The *decoded* key is always 32 characters (or 256 bytes) long.
     * can be optionally password-encrypted using the 128-bit key, and then be automatically detected (and password requested) when the key is used
     * can optionally have its password cached for 15 minutes locally on the machine using `memcached` or using a `dRB` server
 * Rich command line interface with some innovative features, such as inline editing of an encrypted file, using your favorite `$EDITOR`.
 * (OS-X Only): Ability to create, add and delete generic password entries from the Mac OS-X KeyChain, and to leverage the KeyChain to store sensitive private keys.

## Development---

Please help us to maintain this collection by using reactions (:+1:, :-1:, ...) and comments to express your feelings.