### PR TITLE
Add connection_pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 
 ## Database Tools
 
+* [connection_pool](https://github.com/mperham/connection_pool) - Generic connection pooling for Ruby, that can be used with anything, e.g. Redis, Dalli, etc.
 * [Database Cleaner](https://github.com/DatabaseCleaner/database_cleaner) - Database Cleaner is a set of strategies for cleaning your database in Ruby.
 * [Foreigner](https://github.com/matthuhiggins/foreigner) - Adds foreign key helpers to migrations and correctly dumps foreign keys to schema.rb.
 * [Large Hadron Migrator](https://github.com/soundcloud/lhm) - Online MySQL schema migrations without locking the table.


### PR DESCRIPTION
## Project

[connection_pool](https://github.com/mperham/connection_pool)

## What is this Ruby project?

This project makes it easy to create connection pools for any database. ActiveRecord has it own Connection Pool, but you can use this project to create pooling for Redis, Dali or any Ruby network client.

## What are the main difference between this Ruby project and similar ones?

- This is a very well tested, well estabilished and with lots of contribuitors
- It's simple to use
- It's maintained by [Mike Perham](https://github.com/mperham), the author and maintener of **Sidekiq**.

---

