### PR TITLE
Add timezone to Date and Time Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [montrose](https://github.com/rossta/montrose) - a simple library for expressing, serializing, and enumerating recurring events in Ruby
 * [time-lord](https://github.com/krainboltgreene/time-lord) - Adds extra functionality to the time class.
 * [time_diff](https://github.com/abhidsm/time_diff) - Calculates the difference between two time.
+* [timezone](https://github.com/panthomakos/timezone) - Accurate current and historical timezones and transformations, with support for Geonames and Google latitude - longitude timezone lookups.
 * [TZinfo](https://github.com/tzinfo/tzinfo) - Provides daylight savings aware transformations between times in different timezones.
 * [validates_timeliness](https://github.com/adzap/validates_timeliness) - Date and time validation plugin for ActiveModel and Rails.
 * [yymmdd](https://github.com/sshaw/yymmdd) - Tiny DSL for idiomatic date parsing and formatting.


### PR DESCRIPTION
## Project

`timezone` - https://github.com/panthomakos/timezone

## What is this Ruby project?

This gem provides current and historical timezones - with accurate transformations between local and UTC times. All data is based off the most recent [IANA Timezone Database](https://www.iana.org/time-zones). The gem also includes a Ruby API for looking up timezones (based on latitude - longitude coordinates) from Geonames or Google.

## What are the main difference between this Ruby project and similar ones?

* Up-to-date and in-memory data from IANA Timezone Database - which is not dependent on system `tzdata` packages being installed.
* Easy lookups from Geonames and Google.
* Best-guess handling of time conversions that fall during daylight savings time transitions.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:, ...) and comments to express your feelings.