### PR TITLE
Add rib to IRB category

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [irbtools](https://github.com/janlelis/irbtools) - Improvements for Ruby's IRB.
 * [Looksee](https://github.com/oggy/looksee) - A tool for illustrating the ancestry and method lookup path of objects. Handy for exploring unfamiliar codebases.
 * [Pry](https://github.com/pry/pry) - A powerful alternative to the standard IRB shell for Ruby.
+* [rib](http://rib.godfat.org) - A lightweight and extensible IRB replacement.
 
 ## Logging
 


### PR DESCRIPTION
## Project

rib - http://rib.godfat.org/

## What is this Ruby project?

A lightweight and extensible irb replacement.
This project has been in development for 6 years now, and is pretty mature. Many plugin's are provided to make your life easier.

## What are the main difference between this Ruby project and similar ones?

Rib aims to be light compared to other alternatives, which means it starts very fast.
It also provide a simpler environment to develop its plugins.
It does not have lexical parsing bugs which IRB has (see the site for details).

---

Please help us to maintain this collection by using reactions (:+1:, :-1:, ...) and comments to express your feelings.