### PR TITLE
Add Dependabot - Automated dependency update pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1210,6 +1210,7 @@ Online tools, services and APIs to simplify development.
 * [AppSignal](https://appsignal.com) - Better monitoring for your Rails applications.
 * [Codacy](https://www.codacy.com) - Automated Code Review for Ruby, Rails, JS, PHP, Python etc. Security, Coverage & Quality.
 * [CodeClimate](https://codeclimate.com) - Quality & security analysis for Ruby on Rails and Javascript.
+* [Dependabot](https://dependabot.com) - Automated dependency update pull requests.
 * [deppbot](https://www.deppbot.com) - Automated Security and Dependency Updates.
 * [Gemnasium](https://gemnasium.com) - Monitor your project dependencies and alert you about updates and security vulnerabilities.
 * [GitHub](https://github.com) - Powerful collaboration, code review, and code management for open source and private projects.


### PR DESCRIPTION
## Project

[Dependabot](https://dependabot.com)

## What is this Ruby project?

Creates dependency update pull requests for Ruby projects (and JS, Python and PHP).

## What are the main difference between this Ruby project and similar ones?

Different to `deppbot` (which is already listed) as it creates individual PRs for each update, rather than one bulk update, and also suggests out-of-range updates when available. Used by over 600 Ruby projects and listed in the GitHub marketplace. Also, it's free for private repos on personal accounts.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:, ...) and comments to express your feelings.