### PR TITLE
Add Rails Event Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
   * [Encryption](#encryption)
   * [Environment Management](#environment-management)
   * [Error Handling](#error-handling)
+  * [Event-driven architecture](#event-driven-architecture)
   * [Feature Flippers and A/B Testing](#feature-flippers-and-ab-testing)
   * [File Upload](#file-upload)
   * [File System](#file-system)
@@ -559,6 +560,10 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Honeybadger](https://www.honeybadger.io/) - Exception, uptime, and performance monitoring for Ruby.
 * [Nesty](https://github.com/skorks/nesty) - Nested exceptions for Ruby.
 * [Raven Ruby](https://github.com/getsentry/raven-ruby) - Raven is a Ruby client for Sentry.
+
+## Event-driven architecture
+
+* [Rails Event Store (RES)](https://github.com/RailsEventStore/rails_event_store) - a library for publishing, consuming, storing and retrieving events. It's your best companion for going with an event-driven architecture for your Rails application.
 
 ## Feature Flippers and A/B Testing
 


### PR DESCRIPTION
## Project

Rails Event Store a.k.a. RES - https://github.com/RailsEventStore/rails_event_store
 
## What is this Ruby project?

Rails Event Store (RES) is a library for publishing, consuming, storing and retrieving events. It's your best companion for going with an event-driven architecture for your Rails application.

## What are the main difference between this Ruby project and similar ones?

I think that none of similar tools are present on the list currently. I proposed a separate category, but it can probably fit into `Abstraction` one. 

You can use it:

* as your Publish-Subscribe bus
* to decouple core business logic from external concerns in Hexagonal style architectures
* as an alternative to ActiveRecord callbacks and Observers
* as a communication layer between loosely coupled components
* to react to published events synchronously or asynchronously
* to extract side-effects (notifications, metrics etc) from your controllers and services into event handlers
* to build an audit-log
* to create read-models
* to implement event-sourcing

---

Please help us to maintain this collection by using reactions (:+1:, :-1:, ...) and comments to express your feelings.