### PR TITLE
Add ruby-vips

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,6 +666,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Phasion](https://github.com/westonplatter/phashion) - Ruby wrapper around pHash, the perceptual hash library for detecting duplicate multimedia files.
 * [PSD.rb](https://github.com/layervault/psd.rb) - Parse Photoshop files in Ruby with ease.
 * [RMagick](https://github.com/rmagick/rmagick) - RMagick is an interface between Ruby and ImageMagick.
+* [ruby-vips](https://github.com/jcupitt/ruby-vips) - A binding for the libvips image processing library.
 * [Skeptick](https://github.com/maxim/skeptick) - Skeptick is an all-purpose DSL for building and running ImageMagick commands.
 
 ## Implementations/Compilers


### PR DESCRIPTION
## Project

https://github.com/jcupitt/ruby-vips

## What is this Ruby project?

Ruby extension for the libvips image processing library. 

---

Please help us to maintain this collection by using reactions (:+1:, :-1:, ...) and comments to express your feelings.