### PR TITLE
Add ComfyBootstrapForm (Form Builder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 * [Abracadabra](https://github.com/TrevorHinesley/abracadabra) - The gem that swaps out text with a fully-compliant Rails form in one click.
 * [Cocoon](https://github.com/nathanvda/cocoon) - Dynamic nested forms using jQuery made easy; works with formtastic, simple_form or default forms.
+* [ComfyBootstrapForm](https://github.com/comfy/comfy-bootstrap-form) - Rails form builder that makes it easy to create forms with Bootstrap 4 markup 
 * [Formtastic](https://github.com/justinfrench/formtastic) - A Rails form builder plugin with semantically rich and accessible markup.
 * [Rails Bootstrap Forms](https://github.com/bootstrap-ruby/rails-bootstrap-forms) - Rails form builder that makes it super easy to create beautiful-looking forms with Twitter Bootstrap 3+.
 * [Reform](https://github.com/apotonick/reform) - Gives you a form object with validations and nested setup of models. It is completely framework-agnostic and doesn't care about your database.


### PR DESCRIPTION
## Project

ComfyBootstrapForm https://github.com/comfy/comfy-bootstrap-form

## What is this Ruby project?

It's a form builder that extends default `ActionView::Helpers::FormBuilder` in order to generate Bootstrap 4 markup for form elements.

## What are the main difference between this Ruby project and similar ones?

Currently, this is the only form builder that properly supports Bootstrap 4 markup and works in Rails 5.2 by wrapping`form_with` form helper. Rails 5.0+ versions are also supported as `form_for` is wrapped as well. Other form builders are either very out-of-date or not planning to support Bootstrap 4 at all.

Now it's a direct dependency of [ComfortableMexicanSofa CMS](https://github.com/comfy/comfortable-mexican-sofa) that uses Bootstrap 4 in the admin area.

Cheers!