### PR TITLE
remove pull review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1232,7 +1232,6 @@ Online tools, services and APIs to simplify development.
 * [Inch CI](http://inch-ci.org/) - Documentation badges for Ruby projects.
 * [Nanobox](https://github.com/nanobox-io/nanobox) - A micro-PaaS (μPaaS) for creating consistent, isolated, Ruby environments deployable anywhere https://nanobox.io.
 * [OctoLinker](https://github.com/OctoLinker/browser-extension) - Navigate through projects on GitHub.com efficiently with the OctoLinker browser extension.
-* [PullReview](https://www.pullreview.com/) - Automated code review for Ruby and Rails - from style to security.
 * [SemaphoreCI](https://semaphoreapp.com/) - Hosted continuous integration and deployment service for open source and private projects.
 * [SideCI](https://www.sideci.com) - Automated Code Review with GitHub PR. - Monitoring Style Violations, Quality, Security, Dependencies.
 * [Travis CI.com](https://travis-ci.com) - Take care of running your tests and deploying your private apps.


### PR DESCRIPTION
## Project

[Pull Review](https://www.pullreview.com/) with website https://www.pullreview.com/, which redirects to [this blog post](http://blog.8thcolor.com/en/2018/02/the-end/)

From the blog post, it says pull review no longer has enough incoming to cover the costs, and ended about 3 weeks ago. I suppose the link could be left in memory/honour, but it doesn't seem to be active anymore.

## What is this Ruby project?

 Automated code review for Ruby and Rails - from style to security.

## What are the main difference between this Ruby project and similar ones?
Other projects seem to still be worked upon.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.