### PR TITLE
Add Terrapin (new version of the cocaine library)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,6 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 ## CLI Builder
 
 * [Clamp](https://github.com/mdub/clamp) - A command-line application framework.
-* [Cocaine](https://github.com/thoughtbot/cocaine) - A small library for doing (command) lines.
 * [Commander](https://github.com/commander-rb/commander) - The complete solution for Ruby command-line executables.
 * [GLI](https://github.com/davetron5000/gli) - Git-Like Interface Command Line Parser.
 * [Main](https://github.com/ahoward/main) - A class factory and DSL for generating command line programs real quick.

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Main](https://github.com/ahoward/main) - A class factory and DSL for generating command line programs real quick.
 * [Rake](https://github.com/ruby/rake) - A make-like build utility for Ruby.
 * [Slop](https://github.com/leejarvis/slop) - Simple Lightweight Option Parsing.
+* [Terrapin](https://github.com/thoughtbot/terrapin) - A small command line library (Formerly Cocaine). 
 * [Thor](http://whatisthor.com) - A toolkit for building powerful command-line interfaces.
 * [Trollop](https://github.com/manageiq/trollop) - A commandline option parser for Ruby that just gets out of your way.
 * [TTY](https://github.com/peter-murach/tty) - Toolbox for developing CLI clients.


### PR DESCRIPTION
## Project
Terrapin 
- [Github](https://github.com/thoughtbot/terrapin)
- [RubyGems](https://rubygems.org/gems/terrapin)

## What is this Ruby project?
The project is the new version of the cocaine library, that is currently on the list.
All features are almost identical. 

## What are the main difference between this Ruby project and similar ones?
Terrapin retains the same syntax/api as Cocaine. (examples from the README)

```
line = Terrapin::CommandLine.new("echo", "hello 'world'")
line.command # => "echo hello 'world'"
line.run # => "hello world\n"
```

and can have interpolated arguments like so

```
line = Terrapin::CommandLine.new("convert", ":in -scale :resolution :out")
line.command(in: "omg.jpg",
             resolution: "32x32",
             out: "omg_thumb.jpg")
# => "convert 'omg.jpg' -scale '32x32' 'omg_thumb.jpg'"
```
---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.