### PR TITLE
Add RubyTest, Lemon and microTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1091,11 +1091,14 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
   * [Cutest](https://github.com/djanowski/cutest) - Isolated tests in Ruby.
   * [Howitzer](https://github.com/strongqa/howitzer) - Ruby based framework for acceptance testing
   * [Konacha](https://github.com/jfirebaugh/konacha) - Test your Rails application's JavaScript with the mocha test framework and chai assertion library.
+  * [Lemon](https://github.com/rubyworks/lemon) - A unit testing framework that enforces method coverage, built with RubyTest.
+  * [microTest](https://github.com/rubyworks/microtest) - a minitest clone built with RubyTest.
   * [minitest](https://github.com/seattlerb/minitest) - minitest provides a complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking.
   * [RR](https://github.com/rr/rr) - A test double framework that features a rich selection of double techniques and a terse syntax.
   * [shoulda-matchers](https://github.com/thoughtbot/shoulda-matchers) - Provides Test::Unit- and RSpec-compatible one-liners that test common Rails functionality. These tests would otherwise be much longer, more complex, and error-prone.
   * [Spinach](https://github.com/codegram/spinach) - Spinach is a high-level BDD framework that leverages the expressive Gherkin language (used by Cucumber) to help you define executable specifications of your application or library's acceptance criteria.
   * [Spork](https://github.com/sporkrb/spork) - A DRb server for testing frameworks (RSpec / Cucumber currently).
+  * [RubyTest](https://rubyworks.github.com/rubytest) - Meta-testing framework for writing other test frameworks, either general-purpose or specialized to the needs of an application. Some general purpose test frameworks built with RubyTest are Lemon and microTest.
   * [Test::Unit](http://test-unit.github.io) - Test::Unit is a xUnit family unit testing framework for Ruby.
 * Fake Data
   * [Fabrication](http://fabricationgem.org/) - A simple and powerful object generation library.


### PR DESCRIPTION
## Project

[RubyTest](https://rubyworks.github.com/rubytest), along with [Lemon](https://github.com/rubyworks/lemon) and [microTest](https://github.com/rubyworks/microtest).

## What is this Ruby project?

RubyTest is a meta-testing framework that makes it easy to write other test frameworks. These can be general purpose or specialized for a specific application. Two general-purpose frameworks written on top of RubyTest are Lemon and microTest.

## What are the main difference between this Ruby project and similar ones?

RubyTest is a meta-framework. While one could write tests directly using RubyTest, it is designed to be used as an API for creating other test frameworks.

Lemon was written to test Ruby Facets. It differs from other unit testing frameworks in that it enforces method coverage.

microTest is clone of minitest. They are essentially the same, however, using microTest allows for the utilization/interfacing with other tools that work with RubyTest, such as [Tapout](https://github.com/rubyworks/tapout).
