### PR TITLE
Add WeTransfer SDK to Third-party API list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1155,6 +1155,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [twilio-ruby](https://github.com/twilio/twilio-ruby) - A module for using the Twilio REST API and generating valid TwiML.
 * [twitter](https://github.com/sferik/twitter) - A Ruby interface to the Twitter API.
 * [wikipedia](https://github.com/kenpratt/wikipedia-client) - Ruby client for the Wikipedia API.
+* [WeTransfer](https://github.com/WeTransfer/wetransfer_ruby_sdk) - Ruby SDK for the WeTransfer API.
 * [Yt](https://github.com/Fullscreen/yt) - An object-oriented Ruby client for YouTube API V3.
 
 ## Video


### PR DESCRIPTION
## Project

Wetransfer Ruby SDK,
[Wetransfer SDK on Github](https://github.com/WeTransfer/wetransfer_ruby_sdk)
[Wetransfer SDK on Rubygems](https://rubygems.org/gems/wetransfer)
[Wetransfer developers portal](https://developers.wetransfer.com/)

## What is this Ruby project?

This ruby project is the SDK for using the WeTransfer API. The SDK allows users to upload files and retrieve a url of where their files have been uploaded to

## What are the main difference between this Ruby project and similar ones?

There are no other similar projects that talk to the same API  

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.