### PR TITLE
Add DeepPluck

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,6 +811,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * Misc
   * [ActiveRecord::Turntable](https://github.com/drecom/activerecord-turntable) - A database sharding extension for ActiveRecord.
   * [ActiveValidators](https://github.com/franckverrot/activevalidators) - An exhaustive collection of off-the-shelf and tested ActiveModel/ActiveRecord validations.
+  * [DeepPluck](https://github.com/khiav223577/deep_pluck) - Allow you to pluck attributes from nested associations without loading a bunch of records.
   * [Enumerize](https://github.com/brainspec/enumerize) - Enumerated attributes with I18n and ActiveRecord/Mongoid/MongoMapper support.
   * [Goldiloader](https://github.com/salsify/goldiloader) - Automatic ActiveRecord eager loading.
   * [mini_record](https://github.com/DAddYE/mini_record) - ActiveRecord meets DataMapper, with MiniRecord you are be able to write schema inside your models.


### PR DESCRIPTION
## Project

Github:
https://github.com/khiav223577/deep_pluck

Rubygems:
https://rubygems.org/gems/deep_pluck

## What is this Ruby project?

`DeepPluck` allows you to pluck attributes from nested associations without loading a bunch of records.

It could be 40 times faster than using `#as_json` when you are going to select 10,000 emails from database (see the [benchmark](https://github.com/khiav223577/deep_pluck#better-performance)).

## What are the main difference between this Ruby project and similar ones?

Rails has built-in `pluck` method which could help you select attributes faster. It is similar to `deep_pluck`, but doesn't have the ability to select attributes from nested associations.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.