### PR TITLE
Add Ciri - Ruby implementation of Ethereum

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 ## Cryptocurrencies and Blockchains
 
 * [Blockchain Lite](https://github.com/openblockchains/blockchain.lite.rb) - Build your own blockchains with crypto hashes; revolutionize the world with blockchains, blockchains, blockchains one block at a time.
+* [Ciri](https://github.com/ciri-ethereum/ciri) - Ruby implementation of Ethereum.
 
 ## Dashboards
 


### PR DESCRIPTION
Ciri - Ruby implementation of Ethereum

## Project

Ciri - https://github.com/ciri-ethereum/ciri

## What is this Ruby project?

Ethereum implementation.

## What are the main difference between this Ruby project and similar ones?

There is already a ruby implementation of Ethereum project, but seems it is deprecated(this https://github.com/cryptape/ruby-ethereum).

So I think Ciri is the only actively development Ruby implementation of Ethereum.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.