### PR TITLE
Add HTTPX gem - a cool http client

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Device Detector](https://github.com/podigee/device_detector) - A precise and fast user agent parser and device detector, backed by the largest and most up-to-date user agent database.
 * [Http Client](https://github.com/nahi/httpclient) - Gives something like the functionality of libwww-perl (LWP) in Ruby.
 * [HTTP](https://github.com/httprb/http) - The HTTP Gem: a simple Ruby DSL for making HTTP requests.
+* [HTTPX](https://gitlab.com/honeyryderchuck/httpx) - acknowledges the ease-of-use of the [http](https://github.com/httprb/http) gem API (itself inspired by python requests library) which aims at reusing the same facade, extending it for the use cases which the http gem doesn't support.
 * [httparty](https://github.com/jnunemaker/httparty) - Makes http fun again!
 * [Http-2](https://github.com/igrigorik/http-2) - Pure Ruby implementation of HTTP/2 protocol
 * [Patron](https://github.com/toland/patron) - Patron is a Ruby HTTP client library based on libcurl.


### PR DESCRIPTION
## HTTPX

Website: [https://honeyryderchuck.gitlab.io/httpx/](https://honeyryderchuck.gitlab.io/httpx/)
Repo: [https://gitlab.com/honeyryderchuck/httpx](https://gitlab.com/honeyryderchuck/httpx)

## What is this Ruby project?

HTTPX is an HTTP client library for the Ruby programming language.

Among its features, it supports:

- HTTP/2 and HTTP/1.x protocol versions
- Concurrent requests by default
- Simple and chainable API (based on HTTP.rb, itself based on Python Requests)
- Proxy Support (HTTP(S), Socks4/4a/5)
- Simple Timeout System
- Lightweight (explicit feature loading)


And among others

- Compression (gzip, deflate, brotli)
- Authentication (Basic Auth, Digest Auth)
- Cookies
- HTTP/2 Server Push
- H2C Upgrade
- Redirect following

## What are the main difference between this Ruby project and similar ones?

In Ruby, HTTP client implementations are a known cheap commodity. Why this one?

**Concurrency**

This library supports HTTP/2 seamlessly (which means, if the request is secure, and the server support ALPN negotiation AND HTTP/2, the request will be made through HTTP/2). If you pass multiple URIs, and they can utilize the same connection, they will run concurrently in it. 

However if the server supports HTTP/1.1, it will try to use HTTP pipelining, falling back to 1 request at a time if the server doesn't support it (if the server support Keep-Alive connections, it will reuse the same connection).


**Clean API**

`HTTPX` acknowledges the ease-of-use of the [http](https://github.com/httprb/http) gem API (itself inspired by python [requests](http://docs.python-requests.org/en/latest/) library). It therefore aims at reusing the same facade, extending it for the use cases which the http gem doesn't support.


**Lightweight**

It ships with a plugin system similar to the ones used by [sequel](https://github.com/jeremyevans/sequel), [roda](https://github.com/jeremyevans/roda) or [shrine](https://github.com/janko-m/shrine).

It means that it loads the bare minimum to perform requests, and the user has to explicitly load the plugins, in order to get the features he/she needs.

It also means that it ships with the minimum amount of dependencies.


**Easy to test**

The test suite runs against [httpbin proxied over nghttp2](https://nghttp2.org/httpbin/), so there are no mocking/stubbing false positives. The test suite uses [minitest](https://github.com/seattlerb/minitest), but its matchers usage is (almost) limited to `#assert` (`assert` is all you need).


**Supported Rubies**

All Rubies greater or equal to 2.1, and always latest JRuby.

## Community discussion

https://twin.github.io/httprb-is-great/#comment-3928282557