### PR TITLE
Add hanami cli as CLI builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Clamp](https://github.com/mdub/clamp) - A command-line application framework.
 * [Commander](https://github.com/commander-rb/commander) - The complete solution for Ruby command-line executables.
 * [GLI](https://github.com/davetron5000/gli) - Git-Like Interface Command Line Parser.
+* [Hanami CLI](https://github.com/hanami/cli) - General purpose Command Line Interface (CLI) framework for Ruby.
 * [Main](https://github.com/ahoward/main) - A class factory and DSL for generating command line programs real quick.
 * [Rake](https://github.com/ruby/rake) - A make-like build utility for Ruby.
 * [Slop](https://github.com/leejarvis/slop) - Simple Lightweight Option Parsing.


### PR DESCRIPTION
## Project

In Hanami project, we built Hanami CLI as a general command line interface framework for ruby, it is used in Hanami framework but it can be used alone.

https://github.com/hanami/cli
https://rubygems.org/gems/hanami-cli
http://hanamirb.org

## What is this Ruby project?

You can build command line interfaces using Ruby

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.