### PR TITLE
add flashee project

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Decent Exposure](https://github.com/hashrocket/decent_exposure) - A helper for creating declarative interfaces in controllers.
 * [Docile](https://github.com/ms-ati/docile) - A tiny library that lets you map a DSL (domain specific language) to your Ruby objects in a snap.
 * [dry-rb](https://github.com/dry-rb) -  dry-rb is a collection of next-generation Ruby libraries, each intended to encapsulate a common task.
+* [flashee](https://github.com/jbernsie/flashee) - Helper class to add CSS classes to Rails flash messages.
 * [Interactor](https://github.com/collectiveidea/interactor) - Interactor provides a common interface for performing complex interactions in a single request.
 * [Light Service](https://github.com/adomokos/light-service) - Series of Actions with an emphasis on simplicity.
 * [Mutations](https://github.com/cypriss/mutations) - Compose your business logic into commands that sanitize and validate input.


### PR DESCRIPTION
## Project

Flashee
- https://github.com/jbernsie/flashee
- https://rubygems.org/gems/flashee

## What is this Ruby project?

Flashee provides a helper class and an ERB partial to render Rails flash messages with CSS classes dependant on the type of flash message being rendered. _i.e. when a error message is rendered attach the `danger` class._

## What are the main difference between this Ruby project and similar ones?

Enumerate comparisons.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.