### PR TITLE
add Buffer -  a Ruby Wrapper for the Buffer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1130,6 +1130,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 ## Third-party APIs
 
+* [Buffer](https://github.com/bufferapp/buffer-ruby) - Buffer API Ruby Library
 * [Dropbox](https://github.com/futuresimple/dropbox-api) - Dropbox API Ruby Client.
 * [facy](https://github.com/huydx/facy) - Command line power tool for facebook.
 * [fb_graph2](https://github.com/nov/fb_graph2) - A full-stack Facebook Graph API wrapper.


### PR DESCRIPTION
add buffer API to Third Party

## Project

Buffer (https://github.com/bufferapp/buffer-ruby)
https://buffer.com/developers/libraries/ruby

## What is this Ruby project?

It is a library for connecting with the Buffer Application specifically for tuby 

## What are the main difference between this Ruby project and similar ones?

Only ruby library for buffer by buffer app

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.