### PR TITLE
Add MidiSmtpServer, ruby SMTP-Server Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Mailman](https://github.com/mailman/mailman) - An incoming mail processing microframework in Ruby.
 * [Maily](https://github.com/markets/maily) - A Rails Engine to manage, test and navigate through all your email templates of your app, being able to preview them directly in your browser.
 * [Markerb](https://github.com/plataformatec/markerb) - Allows you to render multipart e-mails from a single template written in Markdown.
+* [MidiSmtpServer](https://github.com/4commerce-technologies-AG/midi-smtp-server) - A small and highly customizable ruby SMTP-Server class with builtin support for AUTH and SSL/STARTTLS.
 * [Pony](https://github.com/benprew/pony) - The express way to send mail from Ruby.
 * [premailer-rails](https://github.com/fphilipe/premailer-rails) - CSS styled emails without the hassle.
 * [Roadie](https://github.com/Mange/roadie) - Roadie tries to make sending HTML emails a little less painful by inlining stylesheets and rewriting relative URLs for you inside your emails.


### PR DESCRIPTION
## Project

MidiSmtpServer

* [Homepage](https://github.com/4commerce-technologies-AG/midi-smtp-server)
* [RubyGems](https://rubygems.org/gems/midi-smtp-server)

## What is this Ruby project?

MidiSmtpServer is a small and highly customizable ruby SMTP-Server. As a library it is mainly designed to be integrated into your projects as serving a SMTP-Server service.

## What are the main difference between this Ruby project and similar ones?

* older one (MiniSmtpServer) is deprecated and less functional
* well tested and in production use for a number of years
* support for authentication
* support for encryption

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.