### PR TITLE
Replace `Trollop` (CLI) with `Optimist`

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,11 +246,11 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Commander](https://github.com/commander-rb/commander) - The complete solution for Ruby command-line executables.
 * [GLI](https://github.com/davetron5000/gli) - Git-Like Interface Command Line Parser.
 * [Main](https://github.com/ahoward/main) - A class factory and DSL for generating command line programs real quick.
+* [Optimist](https://manageiq.github.io/optimist/) - A commandline option parser for Ruby that just gets out of your way.
 * [Rake](https://github.com/ruby/rake) - A make-like build utility for Ruby.
 * [Slop](https://github.com/leejarvis/slop) - Simple Lightweight Option Parsing.
 * [Terrapin](https://github.com/thoughtbot/terrapin) - A small command line library (Formerly Cocaine). 
 * [Thor](http://whatisthor.com) - A toolkit for building powerful command-line interfaces.
-* [Trollop](https://github.com/manageiq/trollop) - A commandline option parser for Ruby that just gets out of your way.
 * [TTY](https://github.com/peter-murach/tty) - Toolbox for developing CLI clients.
 
 ## CLI Utilities


### PR DESCRIPTION
```
Post-install message from trollop:
!    The 'trollop' gem has been deprecated and has been replaced by 'optimist'.
!    See: https://rubygems.org/gems/optimist
!    And: https://github.com/ManageIQ/optimist
```

Resolve #832