### PR TITLE
Remove paperclip as it has been officially deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [attache](https://github.com/choonkeat/attache) - Standalone image and file server to decouple your app from file management concerns.
 * [CarrierWave](https://github.com/carrierwaveuploader/carrierwave) - Classier solution for file uploads for Rails, Sinatra and other Ruby web frameworks.
 * [DragonFly](https://github.com/markevans/dragonfly) - A Ruby gem for on-the-fly processing - suitable for image uploading in Rails, Sinatra and much more!.
-* [PaperClip](https://github.com/thoughtbot/paperclip) - Easy file attachment management for ActiveRecord.
+* [PaperClip](https://github.com/thoughtbot/paperclip) - Easy file attachment management for ActiveRecord. Deprecated as of May 14, 2018.
 * [rack-secure-upload](https://github.com/dtaniwaki/rack-secure-upload) - Upload files securely.
 * [Refile](https://github.com/refile/refile) - A modern file upload library for Ruby applications, Refile is an attempt by CarrierWave's original author to fix the design mistakes and overengineering in CarrierWave.
 * [Shrine](https://github.com/janko-m/shrine) - Toolkit for handling file uploads in Ruby.


### PR DESCRIPTION
Paperclip is now deprecated and should not be used so it seems like it should be removed.

ref: https://robots.thoughtbot.com/closing-the-trombone


## Project

https://github.com/thoughtbot/paperclip


---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.