### PR TITLE
Adding Pagy gem to awesome ruby readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,6 +860,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Kaminari](https://github.com/amatsuda/kaminari) - A Scope & Engine based, clean, powerful, customizable and sophisticated paginator for modern web app frameworks and ORMs.
 * [order_query](https://github.com/glebm/order_query) - A keyset pagination library to find the next or previous record(s) relative to the current one efficiently, e.g. for infinite scroll.
 * [will_paginate](https://github.com/mislav/will_paginate) - A pagination library that integrates with Ruby on Rails, Sinatra, Merb, DataMapper and Sequel.
+* [Pagy](https://github.com/ddnexus/pagy) - Pagy is the ultimate pagination gem that outperforms the others in each and every benchmark and comparison. More details can be found on [Pagy Wiki](https://ddnexus.github.io/pagy/index).
 
 ## PDF
 

--- a/README.md
+++ b/README.md
@@ -859,8 +859,8 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 * [Kaminari](https://github.com/amatsuda/kaminari) - A Scope & Engine based, clean, powerful, customizable and sophisticated paginator for modern web app frameworks and ORMs.
 * [order_query](https://github.com/glebm/order_query) - A keyset pagination library to find the next or previous record(s) relative to the current one efficiently, e.g. for infinite scroll.
-* [will_paginate](https://github.com/mislav/will_paginate) - A pagination library that integrates with Ruby on Rails, Sinatra, Merb, DataMapper and Sequel.
 * [Pagy](https://github.com/ddnexus/pagy) - Pagy is the ultimate pagination gem that outperforms the others in each and every benchmark and comparison. More details can be found on [Pagy Wiki](https://ddnexus.github.io/pagy/index).
+* [will_paginate](https://github.com/mislav/will_paginate) - A pagination library that integrates with Ruby on Rails, Sinatra, Merb, DataMapper and Sequel.
 
 ## PDF
 


### PR DESCRIPTION
Adding Pagy gem to awesome ruby readme

## Project

[Pagy](https://github.com/ddnexus/pagy)
[Pagy Wiki](https://ddnexus.github.io/pagy/index)

Thanks for your work on *pagy* @ddnexux

## What is this Ruby project?

Pagy is the ultimate pagination gem that outperforms the others in each and every benchmark and comparison.

## What are the main difference between this Ruby project and similar ones?

Pagy is the ultimate pagination gem that outperforms the others in each and every benchmark and comparison. [Detailed Gem comparisons](https://ddnexus.github.io/pagination-comparison/gems.html)

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.