### PR TITLE
Add gitarro rubygem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1122,6 +1122,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
   * [Watir](https://github.com/watir/watir/) - Web application testing in Ruby.
 * Extra
   * [Appraisal](https://github.com/thoughtbot/appraisal) - Appraisal integrates with bundler and rake to test your library against different versions of dependencies.
+  * [gitarro](https://github.com/openSUSE/gitarro) - Run, retrigger, handle all type and OS-indipendent tests against your GitHub Pull Requests.
   * [Knapsack](https://github.com/ArturT/knapsack) - Optimal test suite parallelisation across CI nodes for RSpec, Cucumber, Minitest, Spinach and Turnip.
   * [mutant](https://github.com/mbj/mutant) - Mutant is a mutation testing tool for Ruby.
   * [Parallel Tests](https://github.com/grosser/parallel_tests) - Speedup Test::Unit + RSpec + Cucumber by running parallel on multiple CPUs (or cores).


### PR DESCRIPTION
## Project

https://opensuse.github.io/gitarro/

## What is this Ruby project?


gitarro run tests on GitHub PRs using almost any script,language or binary, it integrate easy with other tools.

Gitarro use the official Github API, written in Ruby (Octokit)

## What are the main difference between this Ruby project and similar ones?
There is no such a project for ruby at moment.

___


Please help us to maintain this collection by using reactions (:+1:, :-1:, ...) and comments to express your feelings.