### PR TITLE
Add syslogger in Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,6 +720,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [MongoDB Logger](https://github.com/le0pard/mongodb_logger) - MongoDB logger for Rails.
 * [Scrolls](https://github.com/asenchi/scrolls) - Simple logging.
 * [Semantic Logger](https://rocketjob.github.io/semantic_logger/) - Scalable, next generation enterprise logging for Ruby.
+* [Syslogger](https://github.com/crohr/syslogger) - A drop-in replacement for the standard Logger Ruby library, that logs to the syslog instead of a log file.
 * [Yell](https://github.com/rudionrails/yell) - Your Extensible Logging Library.
 
 ## Machine Learning


### PR DESCRIPTION
## Project

https://github.com/crohr/syslogger

## What is this Ruby project?

A drop-in replacement for the standard Logger Ruby library, that logs to the syslog instead of a log file.

## What are the main difference between this Ruby project and similar ones?

* it logs to the syslog instead of a log file
* Contrary to the SyslogLogger library, you can specify the facility and the syslog options.

See issue https://github.com/markets/awesome-ruby/issues/844
---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.