### PR TITLE
Add Cloudsmith (a Rubygems-compatible service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,6 +875,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * Gems
   * [Bundler](http://bundler.io) - Manage your application's gem dependencies with less pain.
   * [RubyGems](https://rubygems.org) - Community's gem hosting service.
+  * [Cloudsmith](https://cloudsmith.io) - A fully managed package management SaaS with support for Rubygems (and many others).
 * Packages and Applications
   * [Berkshelf](https://github.com/berkshelf/berkshelf) - A Chef Cookbook manager.
   * [CocoaPods](https://github.com/CocoaPods/CocoaPods) - The Objective-C dependency manager.


### PR DESCRIPTION
## Project

[Cloudsmith](https://cloudsmith.io) - https://cloudsmith.io

## What is this Ruby project?

This PR adds a link to [Cloudsmith](https://cloudsmith.io), which is a package management service SaaS. It's commercial, but it is completely free for open-source and it has generous free tiers otherwise. It has first-class support for Rubygems-compatible repositories (and many other package formats, such as Python/Npm), plus org/teams management, granular access controls, private repositories, repository-specific entitlements, a worldwide content distribution network, webhooks, access logs, etc.

## What are the main difference between this Ruby project and similar ones?

It's similar to [Gemfury](https://gemfury.com), which is another excellent service for managed hosting of Rubygems. Cloudsmith has a focus on simplicity and an ethos for being as secure as possible by default, which is seen in the breadth of features offered (e.g. automatic GPG signing, entitlements control, geo/IP control, etc.) It's particularly useful if combining Ruby-based technologies with others (e.g. Npm).

*Full disclosure:* I work at Cloudsmith.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.