### PR TITLE
Add health monitor gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,8 +941,8 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Eye](https://github.com/kostya/eye) - Process monitoring tool. Inspired from Bluepill and God.
 * [Foreman](https://github.com/ddollar/foreman) - Manage Procfile-based applications.
 * [God](https://github.com/mojombo/god) - An easy to configure, easy to extend monitoring framework written in Ruby.
-* [Procodile](https://github.com/adamcooke/procodile) - Run processes in the background (and foreground) on Mac & Linux from a Procfile.
 * [Health Monitor Rails](https://github.com/lbeder/health-monitor-rails) - A mountable Rails plug-in to check health of services (Database, Cache, Sidekiq, Redis, e.t.c.) used by the Rails app.
+* [Procodile](https://github.com/adamcooke/procodile) - Run processes in the background (and foreground) on Mac & Linux from a Procfile.
 
 ## Processes
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
   * [Git Tools](#git-tools)
   * [GraphQL](#graphql)
   * [GUI](#gui)
+  * [Health Monitoring](#health-monitoring)
   * [HTML/XML Parsing](#htmlxml-parsing)
   * [HTTP Clients and tools](#http-clients-and-tools)
   * [Image Processing](#image-processing)
@@ -657,6 +658,10 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [qtbindings](https://github.com/ryanmelt/qtbindings) - Allows the QT Gui toolkit to be used from Ruby.
 * [RubyGnome2](http://ruby-gnome2.sourceforge.jp/) - Ruby language bindings for the GNOME 2.0 development environment.
 * [Shoes](http://shoesrb.com) - Shoes makes building little graphical programs for Mac, Windows, and Linux super simple.
+
+## Health Monitoring
+
+* [health-monitor-rails](https://github.com/lbeder/health-monitor-rails) - A mountable Rails plug-in to check health of services (Database, Cache, Sidekiq, Redis, e.t.c.) used by the Rails app.
 
 ## HTML/XML Parsing
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
   * [Git Tools](#git-tools)
   * [GraphQL](#graphql)
   * [GUI](#gui)
-  * [Health Monitoring](#health-monitoring)
   * [HTML/XML Parsing](#htmlxml-parsing)
   * [HTTP Clients and tools](#http-clients-and-tools)
   * [Image Processing](#image-processing)
@@ -668,10 +667,6 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [RubyGnome2](http://ruby-gnome2.sourceforge.jp/) - Ruby language bindings for the GNOME 2.0 development environment.
 * [Shoes](http://shoesrb.com) - Shoes makes building little graphical programs for Mac, Windows, and Linux super simple.
 
-## Health Monitoring
-
-* [health-monitor-rails](https://github.com/lbeder/health-monitor-rails) - A mountable Rails plug-in to check health of services (Database, Cache, Sidekiq, Redis, e.t.c.) used by the Rails app.
-
 ## HTML/XML Parsing
 
 * [HappyMapper](https://github.com/dam5s/happymapper) - Object to XML mapping library, using Nokogiri.
@@ -947,6 +942,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Foreman](https://github.com/ddollar/foreman) - Manage Procfile-based applications.
 * [God](https://github.com/mojombo/god) - An easy to configure, easy to extend monitoring framework written in Ruby.
 * [Procodile](https://github.com/adamcooke/procodile) - Run processes in the background (and foreground) on Mac & Linux from a Procfile.
+* [Health Monitor Rails](https://github.com/lbeder/health-monitor-rails) - A mountable Rails plug-in to check health of services (Database, Cache, Sidekiq, Redis, e.t.c.) used by the Rails app.
 
 ## Processes
 


### PR DESCRIPTION
## Project

**Health Monitor Rails**
Github: https://github.com/lbeder/health-monitor-rails
RubyGems: https://rubygems.org/gems/health-monitor-rails

## What is this Ruby project?

A mountable Rails plugin to check health of services(DB, sidekiq, Redis) used by the app.

## What are the main difference between this Ruby project and similar ones?

- Simple and minimalistic
- Easy to add new services according to our need
- Offers different response formats(HTML/JSON/XML) for "/check"  endpoint

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.