### PR TITLE
Update Gem Generators Category - Adding Quik Gem & Tool for Project Scaffolding (Git-Powered Script Wizard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,8 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 * [Gemsmith](https://github.com/bkuhlmann/gemsmith) - A command line interface for smithing new Ruby gems.
 * [Hoe](http://www.zenspider.com/projects/hoe.html) - Hoe is a Rake/RubyGems helper for project Rakefiles.
+* [Quik](https://github.com/quikstart/quik) - A quick starter template script wizard (git-powered project scaffolder) and missing code generator for new gems and more.
+
 
 ## Geolocation
 


### PR DESCRIPTION
## Project

Quik  - <https://github.com/quikstart/quik>

## What is this Ruby project?

Let's you qui(c)k start new gems (or gem-packaged jekyll themes,) and more using the quik command line tool - that uses git-powered project scaffolds / templates and scripts.

## What are the main difference between this Ruby project and similar ones?

Main two differenences: 1) the project scaffolds / templates are NOT hard-coded in the gem but are regular "vanilla" git(hub) repos and 2) the wizard scripts uses a mini-language (DSL) in ruby :-).

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.