### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1166,7 +1166,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 ## Third-party APIs
 
-* [Dropbox](https://github.com/futuresimple/dropbox-api) - Dropbox API Ruby Client.
+* [Dropbox](https://github.com/Jesus/dropbox_api) - Ruby client for Dropbox API v2.
 * [facy](https://github.com/huydx/facy) - Command line power tool for facebook.
 * [fb_graph2](https://github.com/nov/fb_graph2) - A full-stack Facebook Graph API wrapper.
 * [flickr](https://github.com/RaVbaker/flickr) - A Ruby interface to the Flickr API.


### PR DESCRIPTION
## Project

https://github.com/Jesus/dropbox_api

## What is this Ruby project?

This is a replacement of the Dropbox API library that was listed. It was deprecated.

## What are the main difference between this Ruby project and similar ones?

For a detailed summary of all gems available: https://www.xuuso.com/programming/2018/11/15/a-summary-of-dropbox-gems.html

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.