### PR TITLE
Adds validates_zipcode to Country Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [normalize_country](https://github.com/sshaw/normalize_country) - Convert country names and codes to a standard, includes a conversion program for XMLs, CSVs and DBs.
 * [Phonelib](https://github.com/daddyz/phonelib) - Ruby gem for phone validation and formatting using Google libphonenumber library data.
 * [Phony](https://github.com/floere/phony) - Fast international phone number (E164 standard) normalizing, splitting and formatting.
+* [validates_zipcode](https://github.com/dgilperez/validates_zipcode) - Multi-country zipcode validation for Rails with support for 259 countries.
 
 ## CRM
 


### PR DESCRIPTION
## Project

GitHub: https://github.com/dgilperez/validates_zipcode
RubyGems: https://rubygems.org/gems/validates_zipcode

## What is this Ruby project?

Adds zipcode / postal code validation support to Rails (ActiveModel). 

It supports postal code formats for virtually every country: 233 country codes. For context, there are 195 currently officially recognized countries and [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1) assigns 249 codes for countries, territories and other areas of geographical interest. 

Regex data taken from several sources, main source being the CLDR database (release 27, around 159). Any other country's postal code will validate without errors.

While it pursues a rather niche objective (it will never go to the moon!), it has being actively maintained for several years, it's tested and documented and gained general usage since [original submission](https://github.com/markets/awesome-ruby/pull/455): about 160k+ downloads in Rubygems at this time, more than others in the same section.

## What are the main difference between this Ruby project and similar ones?

Only similar gem with relevance (similar amount of downloads in Rubygems and Github stars) to my knowledge is [going_postal](https://github.com/globaldev/going_postal). Differences:

* _validates_zipcode_ supports 233 country codes (virtually _all_). _going_postal_ only supports 17 country codes, plus some countries without postal code service (including some errors), which makes it allegedly not suitable for global purposes.  
* _validates_zipcode_ is actively maintained. Last commit to _going_postal_ is 3 years all.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.