### PR TITLE
Adding markdown_helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 ## Markdown Processors
 
 * [kramdown](https://github.com/gettalong/kramdown) - Kramdown is yet-another-markdown-parser but fast, pure Ruby, using a strict syntax definition and supporting several common extensions.
+* [markdown_helper](https://github.com/BurdetteLamar/markdown_helper#markdown-helper) - A markdown pre-processor implementing file inclusion and page TOC (table of contents).
 * [Maruku](https://github.com/bhollis/maruku) - A pure-Ruby Markdown-superset interpreter.
 * [Redcarpet](https://github.com/vmg/redcarpet) - A fast, safe and extensible Markdown to (X)HTML parser.
 * [word-to-markdown](https://github.com/benbalter/word-to-markdown) - Gem to convert Microsoft Word documents to Markdown.


### PR DESCRIPTION
## Markdown Helper

Title:  <code>markdown_helper</code>
GitHub:  https://github.com/BurdetteLamar/markdown_helper#markdown-helper
RubyGems:  https://rubygems.org/gems/markdown_helper

## What is this Ruby project?

<code>markdown_helper</code> is a markdown pre-processor implementing:

* File inclusion (which GitHub has so far refused to support), including nested includes, code highlighting, pre-formatted text.
* Page TOC (table of contents).
