### PR TITLE
Add the Trav3 gem to the Third-party APIs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [soundcloud-ruby](https://github.com/soundcloud/soundcloud-ruby) - Official SoundCloud API Wrapper for Ruby.
 * [t](https://github.com/sferik/t) - A command-line power tool for Twitter.
 * [terjira](https://github.com/keepcosmos/terjira) - A command-line power tool for Jira.
+* [trav3](https://github.com/danielpclark/trav3) Ruby client for the Travis API V3.
 * [tweetstream](https://github.com/tweetstream/tweetstream) - A simple library for consuming Twitter's Streaming API.
 * [twilio-ruby](https://github.com/twilio/twilio-ruby) - A module for using the Twilio REST API and generating valid TwiML.
 * [twitter](https://github.com/sferik/twitter) - A Ruby interface to the Twitter API.


### PR DESCRIPTION
## Trav3

* [Github: danielpclark/trav3](https://github.com/danielpclark/trav3)
* [RubyGems: trav3](https://rubygems.org/gems/trav3)

## What is this Ruby project?

API client for the Travis CI API V3

## What are the main difference between this Ruby project and similar ones?

There are no other Travis CI API clients listed here

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.