### PR TITLE
replace NArray with Numo::NArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -1008,7 +1008,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
   * [Rgl](https://github.com/monora/rgl) - A framework for graph data structures and algorithms.
 * Numerical arrays
   * [NMatrix](https://github.com/sciruby/nmatrix) - Fast numerical linear algebra library for Ruby.
-  * [NArray](https://github.com/masa16/narray) - N-dimensional Numerical Array for Ruby.
+  * [Numo::NArray](https://github.com/ruby-numo/numo-narray) - N-dimensional Numerical Array for Ruby.
   * [mdarray](https://github.com/rbotafogo/mdarray) - Multi dimensional array implemented for JRuby inspired by NumPy.
 * [SciRuby](https://github.com/sciruby/sciruby) - Tools for scientific computation in Ruby/Rails.
   * [statsample](https://github.com/sciruby/statsample) - A suite for basic and advanced statistics on Ruby.


### PR DESCRIPTION
## Numo::NArray
* https://github.com/ruby-numo/numo-narray
* https://rubygems.org/gems/numo-narray

## What is this Ruby project?
N-dimensional array
This project is the successor to Ruby/NArray.

## What are the main difference between this Ruby project and similar ones?
Compared to NMatrix
* NArray is faster. Almost as fast as Numpy right now.
  https://www.slideshare.net/naitoh1/rubydata-tokyo-meetup-2018-naitoh-123262737
* Easy to install. 
* Long history. 
  * A blank from the old version.
  * But development is active in 2019. (NMatrix is not active) 
* It has GPU version. 
  https://github.com/sonots/cumo
* It has a powerful machine learning library
  https://github.com/yoshoku/SVMKit
* It has a deep learning Library
  https://github.com/red-data-tools/red-chainer

* It is Not Sciruby project. 
  * Some popular Sciruby gems use nmatrix.
  * So fewer stars, fewer contributors
* It has no coarse matrix implementation