### PR TITLE
add paloma to view helpers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1200,11 +1200,12 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Streamio FFMPEG](https://github.com/streamio/streamio-ffmpeg) - Simple yet powerful wrapper around the ffmpeg command for reading metadata and transcoding movies.
 * [Video Transcoding](https://github.com/donmelton/video_transcoding) - Tools to transcode, inspect and convert videos.
 
-## View helpers
+## View Helpers
 
 * [auto_html](https://github.com/dejan/auto_html) - Rails extension for transforming URLs to appropriate resource (image, link, YouTube, Vimeo video...).
 * [Bh](https://github.com/fullscreen/bh) - Bootstrap Helpers for Ruby.
 * [gon](https://github.com/gazay/gon) - If you need to send some data to your js files and you don't want to do this with long way through views and parsing - use gon.
+* [Paloma](https://github.com/gnclmorais/paloma) - Page-specific javascript for Rails applications with no external JS dependency
 * [PluggableJs](https://github.com/peresleguine/pluggable_js) - Page-specific javascript for Rails applications with the ability of passing data from a controller.
 
 ## Web Crawling


### PR DESCRIPTION
## Project

Title: Paloma
Github: https://github.com/gnclmorais/paloma
RubyGems: https://rubygems.org/gems/paloma

## What is this Ruby project?

A gem that allows page specific javascript loading

## What are the main difference between this Ruby project and similar ones?

Choose what specific javascript code to run per page.
Easily make ruby variables available on your javascript files.
Write in vanilla javascript, coffeescript, and anything that compiles to js.
No external JS library dependency.
Easy to understand (because it is patterned after Rails controller).
