### PR TITLE
Added FaaStRuby

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
   * [Rails Application Generators](#rails-application-generators)
   * [Robotics](#robotics)
   * [RSS](#rss)
+  * [Serverless](#serverless)
   * [Scheduling](#scheduling)
   * [Scientific](#scientific)
   * [Search](#search)
@@ -988,6 +989,9 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Ratom](https://github.com/seangeo/ratom) - A fast, libxml based, Ruby Atom library.
 * [Simple rss](https://github.com/cardmagic/simple-rss) - A simple, flexible, extensible, and liberal RSS and Atom reader.
 * [Stringer](https://github.com/swanson/stringer) - A self-hosted, anti-social RSS reader.
+
+## Serverless
+* [FaaStRuby](https://faastruby.io) - Serverless Software Development Platform for Ruby and Crystal developers.
 
 ## Scheduling
 


### PR DESCRIPTION
Added Serverless list
Added FaaStRuby to the Serverless list

## Project

* https://github.com/FaaStRuby/
* https://rubygems.org/gems/faastruby
* https://faastruby.io
* https://dev.to/jgaskins/faastruby-serverless-functions-as-a-service-for-ruby-and-crystal-2849
* https://onebitcode.com/faastruby-serverless-ruby/

## What is this Ruby project?

FaaStRuby is a serverless FaaS platform for Ruby developers.

## What are the main difference between this Ruby project and similar ones?

* It has no cold starts, so you can actually develop a web application with it.
* Easy to use CLI.
* Don't need to learn a framework.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.