### PR TITLE
Rename "Artificial intelligence" to "Machine learning"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1008,9 +1008,6 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 ## Scientific
 
-* Artificial intelligence
-  * [AI4R](https://github.com/sergiofierens/ai4r) - Algorithms covering several Artificial intelligence fields.
-  * [ruby-fann](https://github.com/tangledpath/ruby-fann) - Ruby library for interfacing with FANN (Fast Artificial Neural Network).
 * Bindings
   * [ruby-opencv](https://github.com/ruby-opencv/ruby-opencv) - An OpenCV wrapper for Ruby.
 * Classifiers
@@ -1019,6 +1016,9 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * Data analysis/structures
   * [daru](https://github.com/v0dro/daru) - A library for storage, analysis, manipulation and visualization of data in pure Ruby.
   * [Rgl](https://github.com/monora/rgl) - A framework for graph data structures and algorithms.
+* Machine learning
+  * [AI4R](https://github.com/sergiofierens/ai4r) - Algorithms covering several Artificial intelligence fields.
+  * [ruby-fann](https://github.com/tangledpath/ruby-fann) - Ruby library for interfacing with FANN (Fast Artificial Neural Network).
 * Numerical arrays
   * [NMatrix](https://github.com/sciruby/nmatrix) - Fast numerical linear algebra library for Ruby.
   * [Numo::NArray](https://github.com/ruby-numo/numo-narray) - N-dimensional Numerical Array for Ruby.


### PR DESCRIPTION
## Rename "Artificial intelligence" to "Machine learning"
AI is an ambiguous term.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.