### PR TITLE
Removed "plotrb"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1031,7 +1031,6 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
   * [integration](https://github.com/sciruby/integration) - Numerical integration methods, based on original work by Beng.
   * [minimization](https://github.com/sciruby/minimization) - Minimization algorithms on pure Ruby.
   * [publisci](https://github.com/sciruby/publisci) - A toolkit for publishing scientific results to the semantic web.
-  * [plotrb](https://github.com/sciruby/plotrb) - A plotting library in Ruby built on top of Vega and D3.
   * [rb-gsl](https://github.com/SciRuby/rb-gsl) - A ruby interface to GNU Scientific library, with NMatrix support.
 * Specific
   * [BioRuby](https://github.com/bioruby/bioruby) - Library for developing bioinformatics software.


### PR DESCRIPTION
## Plotrb
This is a SciRuby project. (Vega/D3-based plotting gem for Ruby.)
The last update was in 2014. Maintenance is actually stopped.

SciRuby develops Nyaplot, GnuplotRB, Daru::View, rubyplot after this.

We should exchange plotrb for another gem. For example [Daru::View](https://github.com/SciRuby/daru-view)

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.