### PR TITLE
add PyCall to Scientific

### DIFF
--- a/README.md
+++ b/README.md
@@ -1013,6 +1013,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
   * [ruby-fann](https://github.com/tangledpath/ruby-fann) - Ruby library for interfacing with FANN (Fast Artificial Neural Network).
 * Bindings
   * [ruby-opencv](https://github.com/ruby-opencv/ruby-opencv) - An OpenCV wrapper for Ruby.
+  * [PyCall](https://github.com/mrkn/pycall.rb) - Calling Python functions from the Ruby language.
 * Classifiers
   * [classifier-reborn](https://github.com/jekyll/classifier-reborn) - An active fork of Classifier, and general module to allow Bayesian and other types of classifications.
   * [stuff-classifier](https://github.com/alexandru/stuff-classifier) - A library for classifying text into multiple categories.


### PR DESCRIPTION
## Pycall
https://github.com/mrkn/pycall.rb

## What is this Ruby project?

Access all Python functions from Ruby.
https://github.com/mrkn/pycall.rb/blob/master/examples/notebooks/classifier_comparison.ipynb
PyCall is useful when you use pandas, numpy, scikit-learn, keras functions inside Ruby application.

## What are the main difference between this Ruby project and similar ones?

There is no similar project in Ruby.
There is PyCall.jl in Julia Lang. 

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.