### PR TITLE
Add discard gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,6 +841,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
   * [ActsAsParanoid](https://github.com/ActsAsParanoid/acts_as_paranoid) - ActiveRecord plugin allowing you to hide and restore records without actually deleting them.
   * [Audited](https://github.com/collectiveidea/audited) - Audited is an ORM extension for ActiveRecord & MongoMapper that logs all changes to your models.
   * [Destroyed At](https://github.com/dockyard/ruby-destroyed_at) - Allows you to "destroy" an object without deleting the record or associated records.
+  * [Discard](https://github.com/jhawthorn/discard) - A simple ActiveRecord mixin to add conventions for flagging records as discarded.
   * [Espinita](https://github.com/continuum/espinita) - Audit activerecord models like a boss.
   * [marginalia](https://github.com/basecamp/marginalia) - Attach comments to your ActiveRecord queries. By default, it adds the application, controller, and action names as a comment at the end of each query.
   * [mongoid-history](https://github.com/aq1018/mongoid-history) - Multi-user non-linear history tracking, auditing, undo, redo for mongoid.


### PR DESCRIPTION
## Discard gem

https://github.com/jhawthorn/discard - Soft deletes for ActiveRecord done right.

## What is this Ruby project?

A simple ActiveRecord mixin to add conventions for flagging records as discarded.

## What are the main difference between this Ruby project and similar ones?

It's the recommended gem by the Paranoia core.

> `paranoia` has some surprising behaviour (like overriding ActiveRecord's `delete` and `destroy`) and is not recommended for new projects. See [`discard`'s README](https://github.com/jhawthorn/discard#why-not-paranoia-or-acts_as_paranoid) for more details.


---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.