### PR TITLE
Add webpush

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,6 +775,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [RubyMotion](http://www.rubymotion.com) - A revolutionary toolchain that lets you quickly develop and test full-fledged native iOS and OS X applications for iPhone, iPad, Mac and Android.
 * [Ruby Push Notifications](https://github.com/calonso/ruby-push-notifications) - iOS, Android and Windows Phone Push notifications made easy.
 * [Rpush](https://github.com/rpush/rpush) - The push notification service for Ruby which supports Apple Push Notification Service, Google Cloud Messaging, Amazon Device Messaging and Windows Phone Push Notification Service.
+* [webpush](https://github.com/zaru/webpush) - Encryption Utilities for Web Push protocol
 
 ## Money
 


### PR DESCRIPTION
## Project

[webpush](https://github.com/zaru/webpush)
[webpush | Rubygems](https://rubygems.org/gems/webpush/)

## What is this Ruby project?

This gem makes it possible to send push messages to web browsers from Ruby backends using the Web Push Protocol. It supports Message Encryption for Web Push to send messages securely from server to user agent.

## What are the main difference between this Ruby project and similar ones?

I have not seen other implementations as far as I know.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.