### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Seed Fu](https://github.com/mbleigh/seed-fu) - Advanced seed data handling for Rails.
 * [Standby](https://github.com/kenn/standby) - Read from standby databases for ActiveRecord (formerly Slavery).
 * [Upsert](https://github.com/seamusabshere/upsert) - Upsert on MySQL, PostgreSQL, and SQLite3. Transparently creates functions (UDF) for MySQL and PostgreSQL; on SQLite3, uses INSERT OR IGNORE.
+* [execute_sql](https://github.com/igorkasyanchuk/execute_sql) - execute SQL queries directly in rails console and whole app.
 
 ## Date and Time Processing
 
@@ -921,6 +922,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Squid](https://github.com/fullscreen/squid) - Squid · A Ruby library to plot charts in PDF files
 * [Wicked Pdf](https://github.com/mileszs/wicked_pdf) - PDF generator (from HTML) plugin for Ruby on Rails.
 * [Wisepdf](https://github.com/igor-alexandrov/wisepdf) - Wkhtmltopdf wrapper done right.
+* [rails_pdf](https://github.com/igorkasyanchuk/rails_pdf) - wrapper around Chrome headless.  Support HTML/CSS/JS/Charts. Has build-in templates with common pdf-layouts.
 
 ## Performance Monitoring
 


### PR DESCRIPTION
## Project

I want to add 2 projects:

https://github.com/igorkasyanchuk/rails_pdf
https://github.com/igorkasyanchuk/execute_sql

## What is this Ruby project?

"Rails PDF" project allows creating PDF using chrome headless. This approach separates logic of pdf creation. Support html/css/js. You can add JS charts. With support of header/footer.

"Execute SQL" project allows to execute SQL in your rails console and whole app. In addition you can print output in a nice output.

## What are the main difference between this Ruby project and similar ones?

**rails_pdf:**

- fast
- html/css/js
- separate logic
- charts/header/footer
- build-in templates 
- doesn't include any middleware

**execute_sql:**

- execute sql in rails console
- nice output for results of SQL queries

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.