### PR TITLE
Add Rumale

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [rb-libsvm](https://github.com/febeling/rb-libsvm) - Ruby language bindings for LIBSVM. SVM is a machine learning and classification algorithm.
 * [Ruby Datumbox Wrapper](https://github.com/marloncarvalho/ruby-datumbox) - It's a simple Ruby Datumbox Wrapper. At the moment the API currently allows you to build applications that make use of machine learning algorithms.
 * [ruby-fann](https://github.com/tangledpath/ruby-fann) - Ruby library for interfacing with FANN (Fast Artificial Neural Network).
+* [rumale](https://github.com/yoshoku/rumale) - A machine learninig library with interfaces similar to Scikit-Learn.
 * [weka](https://github.com/paulgoetze/weka-jruby) - Machine learning and data mining algorithms for JRuby.
 
 ## Markdown Processors


### PR DESCRIPTION
## Rumale
https://github.com/yoshoku/rumale

## What is this Ruby project?
This library provides a wide range of machine learning algorithms with a uniform interface like scikit-learn. The author is developing in contact with red-data-tools and sciruby-jp. This project has the potential to become Ruby's standard machine learning library in the future. Recently SVMKit was renamed to Rumale (RUby MAchine LEarning) .

## What are the main difference between this Ruby project and similar ones?
Compared to [ai4r](https://github.com/SergioFierens/ai4r), Rumale
- is faster ( using NArray )
- is reliable ( Developed by a data scientist )
- has a consistent interface ( like scikit-learn )
- code is easy to read. 
---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.