### PR TITLE
Add Daru::View

### DIFF
--- a/README.md
+++ b/README.md
@@ -1024,6 +1024,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
   * [stuff-classifier](https://github.com/alexandru/stuff-classifier) - A library for classifying text into multiple categories.
 * Data analysis/structures
   * [daru](https://github.com/v0dro/daru) - A library for storage, analysis, manipulation and visualization of data in pure Ruby.
+  * [Daru::View](https://github.com/SciRuby/daru-view) - A library for easy and interactive plotting on Jupyter Notebooks and web applications.
   * [Rgl](https://github.com/monora/rgl) - A framework for graph data structures and algorithms.
 * Numerical arrays
   * [NMatrix](https://github.com/sciruby/nmatrix) - Fast numerical linear algebra library for Ruby.


### PR DESCRIPTION
## Daru::View
https://github.com/SciRuby/daru-view

## What is this Ruby project?
This Library is for data visualization. Daru-view visualizes Daru::Dataframe and Daru::Vector using Google Charts or Highcharts. It is usually used on Jupyter Notebook.

## What are the main difference between this Ruby project and similar ones?

There is no user-friendly visualization tool in Ruby. I know that Daru::View is far from perfect. But, in some ways, Daru::View is the best visualization library in Ruby right now.

Compared to numo-gnuplot, gnuplot, gnuplotrb, nyaplot, daru-plotlly, rbplotly, daru-plotly, rubyplot, charty,

Daru::View
- is an extension of Daru, which is the most used data frame in Ruby.
- visualize not only series but also data frames. 
- is active. ( There are a lot of similar projects that have finished development. )
- works offline. 
- is interactive.
- can be used with Jupyter Notebook.
- has good documentation. 
- covers almost all the features of Google Charts, and it has complete example notebooks. 
- is reliable because it relies entirely on GoogleChart and Highchart instead of using its original drawing mechanism. 
- is considered for use in web applications.
- is a SciRuby project.
---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.