### PR TITLE
Add Tabulo to CLI Utilities list

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Pastel](https://github.com/peter-murach/pastel) - Terminal output styling with intuitive and clean API.
 * [Ru](https://github.com/tombenner/ru) - Ruby in your shell.
 * [Ruby/Progressbar](https://github.com/jfelchner/ruby-progressbar) - The most flexible text progress bar library for Ruby.
+* [Tabulo](https://github.com/matt-harvey/tabulo) - ASCII table generator with a DRY, "column-based" API; good for tabulating large and unwieldy data sets.
 * [TablePrint](https://github.com/arches/table_print) - Slice your data from multiple DB tables into a single CLI view.
 * [Terminal Table](https://github.com/tj/terminal-table) - Ruby ASCII Table Generator, simple and feature rich.
 * [Tmuxinator](https://github.com/tmuxinator/tmuxinator) - Create and manage complex tmux sessions easily.

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Pastel](https://github.com/peter-murach/pastel) - Terminal output styling with intuitive and clean API.
 * [Ru](https://github.com/tombenner/ru) - Ruby in your shell.
 * [Ruby/Progressbar](https://github.com/jfelchner/ruby-progressbar) - The most flexible text progress bar library for Ruby.
-* [Tabulo](https://github.com/matt-harvey/tabulo) - ASCII table generator with a DRY, "column-based" API; good for tabulating large and unwieldy data sets.
+* [Tabulo](https://github.com/matt-harvey/tabulo) - Ruby ASCII table generator. Produce highly readable terminal tables, even from large, unwieldy data sets and streams.
 * [TablePrint](https://github.com/arches/table_print) - Slice your data from multiple DB tables into a single CLI view.
 * [Terminal Table](https://github.com/tj/terminal-table) - Ruby ASCII Table Generator, simple and feature rich.
 * [Tmuxinator](https://github.com/tmuxinator/tmuxinator) - Create and manage complex tmux sessions easily.


### PR DESCRIPTION
## Project

Title: `tabulo`
GitHub: https://github.com/matt-harvey/tabulo
RubyGems: https://rubygems.org/gems/tabulo

## What is this Ruby project?

Tabulo is an ASCII table generator with a DRY, "column-based" API. Its features make it especially well-suited to tabulating large, unwieldy data sets.

## What are the main difference between this Ruby project and similar ones?

* The initialization interface is structured around building up the table column-by-column, rather than row-by-row. This makes for DRYer initialization code, since the ordering of the columns is expressed only once, rather than being duplicated within each row (and, in particular, between the header row and the body rows).
* You can "shrinkwrap" the table so that it automatically sizes each column, but stops at a certain overall maximum width (which you usually want to be the width of your terminal). This is especially useful when outputting wide data sets that would otherwise become unreadable in virtue of wrapping around the terminal.
* You can the repeat the header row every N rows, which is handy when outputting a very large table.
* A Tabulo::Table is an Enumerable object, so you can make an enumerator for it and then step through it "lazily" a row at a time. This can be useful when tabulating large, open-ended data sets such as some ActiveRecord queries, where you don't want to load the entire underlying collection up front.
* Column alignments have helpful type-based defaults: strings are left-aligned by default, numbers right. 

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.