### PR TITLE
Add yeet db gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Seed Fu](https://github.com/mbleigh/seed-fu) - Advanced seed data handling for Rails.
 * [Standby](https://github.com/kenn/standby) - Read from standby databases for ActiveRecord (formerly Slavery).
 * [Upsert](https://github.com/seamusabshere/upsert) - Upsert on MySQL, PostgreSQL, and SQLite3. Transparently creates functions (UDF) for MySQL and PostgreSQL; on SQLite3, uses INSERT OR IGNORE.
+* [Yeet DBA](https://github.com/KevinColemanInc/yeet_dba) - Automatically add foreign key constraints to your rails db
 
 ## Date and Time Processing
 


### PR DESCRIPTION
## Project

Yeet Dba

https://github.com/kevincolemaninc/yeet_dba

## What is this Ruby project?

Yeet dba creates a rails migration to automatically add foreign key constraints that might be missing on your database.

## What are the main difference between this Ruby project and similar ones?

lol_dba is probably the closest project to this one. lol_dba finds missing indexes. yeet_dba finds missing foreign key constraints.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.