### PR TITLE
Add cuke_modeler gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1179,6 +1179,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
   * [Watir](https://github.com/watir/watir/) - Web application testing in Ruby.
 * Extra
   * [Appraisal](https://github.com/thoughtbot/appraisal) - Appraisal integrates with bundler and rake to test your library against different versions of dependencies.
+  * [cuke_modeler](https://github.com/enkessler/cuke_modeler) - An modeling library for `.feature` files that is an abstration layer on top of the `gherkin` gem, providing a stable base upon which to build other Gherkin related tools.
   * [gitarro](https://github.com/openSUSE/gitarro) - Run, retrigger, handle all type and OS-independent tests against your GitHub Pull Requests.
   * [Knapsack](https://github.com/ArturT/knapsack) - Optimal test suite parallelisation across CI nodes for RSpec, Cucumber, Minitest, Spinach and Turnip.
   * [mutant](https://github.com/mbj/mutant) - Mutant is a mutation testing tool for Ruby.


### PR DESCRIPTION
`cuke_modeler` gem added to 'Testing, Extras' category.

## Project

CukeModeler

GitHub: https://github.com/enkessler/cuke_modeler
RubyGems: https://rubygems.org/gems/cuke_modeler
RubyToolbox: https://www.ruby-toolbox.com/projects/cuke_modeler

## What is this Ruby project?

CukeModeler models test suites written in Gherkin (i.e. `.feature` files) so that they can then be analyzed/manipulated programatically. It is essentially an abstraction layer that sits on top of the `gherkin`/`cucumber-gherkin` gem and is easier and more stable to work with than using those gems directly.

## What are the main difference between this Ruby project and similar ones?

The only similar project is the `gherkin` gem itself, which `cuke_modeler` abstracts away. So...there aren't really any similar projects.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.