### PR TITLE
Add cql gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1180,6 +1180,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
   * [Watir](https://github.com/watir/watir/) - Web application testing in Ruby.
 * Extra
   * [Appraisal](https://github.com/thoughtbot/appraisal) - Appraisal integrates with bundler and rake to test your library against different versions of dependencies.
+  * [CQL](https://github.com/enkessler/cql) - CQL is a library for making queries against Cucumber style test suites.
   * [gitarro](https://github.com/openSUSE/gitarro) - Run, retrigger, handle all type and OS-independent tests against your GitHub Pull Requests.
   * [Knapsack](https://github.com/ArturT/knapsack) - Optimal test suite parallelisation across CI nodes for RSpec, Cucumber, Minitest, Spinach and Turnip.
   * [mutant](https://github.com/mbj/mutant) - Mutant is a mutation testing tool for Ruby.


### PR DESCRIPTION
`cql` gem added to 'Testing, Extras' category.


## Project

CQL

GitHub: https://github.com/enkessler/cql
RubyGems: https://rubygems.org/gems/cql
RubyToolbox: https://www.ruby-toolbox.com/projects/cql


## What is this Ruby project?

CQL is a domain specific language used for querying a Cucumber (or other Gherkin based) test suite. It is built on top of the `cuke_modeler` gem and the goal of CQL is to increase the ease with which useful information can be extracted from a modeled test suite and turned into summarized data or reports.

## What are the main difference between this Ruby project and similar ones?

As far as I know, there are no similar projects.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.