### PR TITLE
Add Square Connect Ruby SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [ROR Ecommerce](https://github.com/drhenner/ror_ecommerce) - A Rails e-commerce platform.
 * [Solidus](https://github.com/solidusio/solidus) - An open source, eCommerce application for high volume retailers.
 * [Spree](https://github.com/spree/spree) - Spree is a complete open source e-commerce solution for Ruby on Rails.
+* [SquareConnect](https://github.com/square/connect-ruby-sdk) - Square's SDK for payments and other Square APIs.
 * [stripe-ruby](https://github.com/stripe/stripe-ruby) - Stripe Ruby bindings.
 
 ## Ebook


### PR DESCRIPTION
## Project

GitHub: https://github.com/square/connect-ruby-sdk
RubyGems: https://rubygems.org/gems/square_connect
Project Page: https://docs.connect.squareup.com/sdks

## What is this Ruby project?

The Square Connect SDK provides an interface a number of Square APIs for taking payments and running a business.

## What are the main difference between this Ruby project and similar ones?

Square is a payment platform that has processed billions of transactions. This gem provides access to APIs for Employees, Labor, Inventory, Orders, and other APIs needed to run a business.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.