### PR TITLE
Add humidifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [AWS SDK for Ruby](https://github.com/aws/aws-sdk-ruby) - The official AWS SDK for Ruby.
 * [browse-everything](https://github.com/projecthydra/browse-everything) - Multi-provider Rails engine providing access to files in cloud storage.
 * [Fog](https://github.com/fog/fog) - The Ruby cloud services library.
+* [humidifier](https://github.com/kddeisz/humidifier) - Programmatically generate and manage AWS CloudFormation templates, stacks, and change sets.
 
 ## CMS
 * [Alchemy CMS](https://alchemy-cms.com) - A powerful, userfriendly and flexible Open Source Rails CMS.


### PR DESCRIPTION
## Project

humidifier

* [github](https://github.com/kddeisz/humidifier)
* [rubygems](https://rubygems.org/gems/humidifier)

## What is this Ruby project?

A ruby CLI/library for interacting with the AWS CloudFormation API.

## What are the main difference between this Ruby project and similar ones?

There are a couple of other CloudFormation ruby libraries (like SparkleFormation). In general most of these libraries act as a fancy JSON generator. This library instead gives you domain objects to represent AWS resources.