### PR TITLE
Add Agoo web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1275,6 +1275,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 ## Web Servers
 
+* [Agoo](https://github.com/ohler55/agoo) - A high performance HTTP server for Ruby that includes GraphQL and WebSocket support.
 * [Goliath](https://github.com/postrank-labs/goliath) - A non-blocking Ruby web server framework.
 * [Iodine](https://github.com/boazsegev/iodine) - An non-blocking HTTP and Websocket web server optimized for Linux/BDS/macOS and Ruby MRI.
 * [Phusion Passenger](https://www.phusionpassenger.com) - Fast and robust web server and application server.


### PR DESCRIPTION
## Project

[Agoo](https://github.com/ohler55/agoo)

[On RubyGems](https://rubygems.org/gems/agoo)

[Benchmarks](https://github.com/planetruby/awesome-webservers/blob/master/benchmark/benchmarks.md)

[More benchmarks](https://github.com/the-benchmarker/web-frameworks)

## What is this Ruby project?

Agoo is fast! It also support WebSockets, SSE, and GraphQL.

## What are the main difference between this Ruby project and similar ones?

- Faster than any other Ruby web server according to independent benchmarks listed above.
- Supports a simple to use GraphQL API.
- Supports WebSockets and SSE using the proposed Rack WebSocket API
