### PR TITLE
Add que-scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1029,6 +1029,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 ## Scheduling
 
 * [minicron](https://github.com/jamesrwhite/minicron) - A system to manage and monitor cron jobs.
+* [que-scheduler](https://github.com/hlascelles/que-scheduler) - A lightweight cron scheduler for the async job worker Que.
 * [resque-scheduler](https://github.com/resque/resque-scheduler) - A light-weight job scheduling system built on top of Resque.
 * [rufus-scheduler](https://github.com/jmettraux/rufus-scheduler) - Job scheduler for Ruby (at, cron, in and every jobs).
 * [Sidekiq-Cron](https://github.com/ondrejbartas/sidekiq-cron) - A scheduling add-on for Sidekiq.


### PR DESCRIPTION
## Project

[que-scheduler](https://github.com/hlascelles/que-scheduler) is a lightweight cron scheduler for the async job worker [que](https://github.com/chanks/que).

* Github: https://github.com/hlascelles/que-scheduler
* Rubygems: https://rubygems.org/gems/que-scheduler
* Downloads: 22k+ 
* Actively maintained

## What is this Ruby project?

que-scheduler is an extension to [que](https://github.com/chanks/que) that adds support for scheduling items using a cron style configuration file.

## What are the main difference between this Ruby project and similar ones?

It is similar to resque-scheduler (in terms of config syntax) but is for use with projects that are based on the que framework, with its greater reliability and ACID scheduling guarantees.
