### PR TITLE
Add arli gem (a CLI-based Arduino Library Manager and new project generator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 ## Encryption
 
 * [RbNaCl](https://github.com/cryptosphere/rbnacl) - Ruby binding to the Networking and Cryptography (NaCl) library.
+* [Sym](https://github.com/kigster/sym) - A time-saving symmetric encryption gem based on OpenSSL that uses 256bit (password-encrypted) keys. Read the key from STDIN, a file, ENV or, on a Mac: OS-X Keychain.
 * [Symmetric Encryption](http://rocketjob.github.io/symmetric-encryption/) - Transparently encrypt ActiveRecord, Mongoid, and MongoMapper attributes. Encrypt passwords in configuration files. Encrypt entire files at rest.
 * [Themis](https://github.com/cossacklabs/themis) - crypto library for painless data security, providing symmetric and asymmetric encryption, secure sockets with forward secrecy, for mobile and server platforms.
 

--- a/README.md
+++ b/README.md
@@ -1010,6 +1010,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 ## Robotics
 
+* [Arli](https://github.com/kigster/arli) - Arli is the CLI tool for searching, installing, and packaging Arduino libraries with a project using a YAML-based Arlifile. It's a "Bundler for Arduino Development". 
 * [Artoo](http://artoo.io) - Next generation robotics framework with support for different platforms: Arduino, Leap Motion, Pebble, Raspberry Pi, etc.
 
 ## RSS


### PR DESCRIPTION
## Project

**Arli — Arduino Library Manager, searcher and installer.**

## What is this Ruby project?

**Arli** is an Arduino library manager with the ability to search libraries, install a single library, or bundle any number of libraries with the project. Arli also is a new project generator based on the [`arduino-cmake`](https://github.com/arduino-cmake/arduino-cmake) build system.

Arli is a rather simple and easy to use command-line tool which offers several indispensable features that help with Arduino project development, in particular for much larger projects with many dependencies and external libraries.

What's more, is that projects generated by Arli's generate command are highly portable from one system to another. Anyone can download your project build/upload with very little work.

[![asciicast](https://asciinema.org/a/155289.svg)](https://asciinema.org/a/155289)

## What are the main difference between this Ruby project and similar ones?

There are no similar Ruby projects, as far as I am aware. 

There is [`platformio`](https://platformio.org) written in Python, and there is a built-in [Arduino Library Manager](https://learn.adafruit.com/adafruit-all-about-arduino-libraries-install-use/library-manager), but nothing in Ruby.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.