### PR TITLE
Add ActsAsTextcaptcha gem to Captchas section

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 
 ## Captchas and anti-spam
 
+* [ActsAsTextcaptcha](https://github.com/matthutchinson/acts_as_textcaptcha) - Protection for Rails models with text-based logic question captchas (from Rob Tuley's textcaptcha.com)
 * [Invisible Captcha](https://github.com/markets/invisible_captcha) - Unobtrusive and flexible spam protection based on the honeypot strategy. It also provides a time-sensitive form submission.
 * [Rakismet](https://github.com/joshfrench/rakismet) - Easy Akismet and TypePad AntiSpam integration for Rails.
 * [reCAPTCHA](https://github.com/ambethia/recaptcha) - reCaptcha API helpers for ruby apps.


### PR DESCRIPTION
## [ActsAsTextcaptcha](http://github.com/matthutchinson/acts_as_textcaptcha)

Text-based logic question captcha's for Rails 🚫🤖

## What is this Ruby project?

ActsAsTextcaptcha provides spam protection for Rails models with text-based logic question captchas. Questions are fetched from [Rob Tuley's](https://twitter.com/robtuley) [textcaptcha.com](http://textcaptcha.com/). They can be solved easily by humans but are tough for robots to crack.

The gem can also be configured with your own questions; as an alternative, or as a fallback to handle any API issues. For reasons on why logic based captchas are a good idea visit [textcaptcha.com](http://textcaptcha.com).

## What are the main difference between this Ruby project and similar ones?

There are no other logic question based captchas on the list, this is a fresh take on captchas that often goes unnoticed. 

---

### Related Links

* [GitHub](http://github.com/matthutchinson/acts_as_textcaptcha)
* [Demo](https://acts-as-textcaptcha-demo.herokuapp.com)
* [Travis CI](http://travis-ci.com/matthutchinson/acts_as_textcaptcha)
* [Maintainability](https://codeclimate.com/github/matthutchinson/acts_as_textcaptcha/maintainability)
* [Test Coverage](https://codeclimate.com/github/matthutchinson/acts_as_textcaptcha/test_coverage)
* [RDoc](http://rdoc.info/projects/matthutchinson/acts_as_textcaptcha)
* [Wiki](http://wiki.github.com/matthutchinson/acts_as_textcaptcha/)
* [Issues](http://github.com/matthutchinson/acts_as_textcaptcha/issues)
* [Report a bug](http://github.com/matthutchinson/acts_as_textcaptcha/issues/new)
* [Gem](http://rubygems.org/gems/acts_as_textcaptcha)
* [TextCaptcha](http://textcaptcha.com) API and service by [Rob Tuley](https://twitter.com/robtuley)