### PR TITLE
Add Rein gem to Database Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Polo](https://github.com/IFTTT/polo) - Creates sample database snapshots to work with real world data in development.
 * [PgHero](https://github.com/ankane/pghero) - Postgres insights made easy.
 * [Rails DB](https://github.com/igorkasyanchuk/rails_db) - Database Viewer and SQL Query Runner.
+* [Rein](https://github.com/nullobject/rein) - Database constraints made easy for ActiveRecord.
 * [Scenic](https://github.com/thoughtbot/scenic) - Versioned database views for Rails.
 * [SchemaPlus](https://github.com/SchemaPlus/schema_plus) - SchemaPlus provides a collection of enhancements and extensions to ActiveRecord
 * [SecondBase](https://github.com/customink/secondbase) - Seamless second database integration for Rails. SecondBase provides support for Rails to manage dual databases by extending ActiveRecord tasks that create, migrate, and test your application.


### PR DESCRIPTION
## Project

Rein - Database constraints made easy for ActiveRecord.

- Github: https://github.com/nullobject/rein
- Rubygems: https://rubygems.org/gems/rein

## What is this Ruby project?

Data integrity is a good thing. Constraining the values allowed by your application at the database-level, rather than at the application-level, is a more robust way of ensuring your data stays sane.

Unfortunately, ActiveRecord doesn't encourage (or even allow) you to use database integrity without resorting to hand-crafted SQL. Rein adds a handful of methods to your ActiveRecord migrations so that you can easily tame the data in your database.

## What are the main difference between this Ruby project and similar ones?

There are no other gem related to database constrains on the list.
