### PR TITLE
Add AssociateRB

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 * [ActiveSupport](https://github.com/rails/rails/tree/master/activesupport) - A collection of utility classes and standard library extensions.
 * [Addressable](https://github.com/sporkmonger/addressable) - Addressable is a replacement for the URI implementation that is part of Ruby's standard library. It more closely conforms to RFC 3986, RFC 3987, and RFC 6570 (level 4), providing support for IRIs and URI templates.
+* [AssociateRB](https://github.com/lucasqueiroz/associate-rb) - Easily convert arrays into hashes.
 * [Finishing Moves](https://github.com/forgecrafted/finishing_moves) - Small, focused, incredibly useful methods added to core Ruby classes. Includes the endlessly useful `nil_chain`.
 * [Hamster](https://github.com/hamstergem/hamster) - Efficient, immutable, and thread-safe collection classes for Ruby.
 * [Hanami::Utils](https://github.com/hanami/utils) - Lightweight, non-monkey-patch class utilities for Hanami and Ruby app.


### PR DESCRIPTION
## Project

### AssociateRB
- [GitHub](https://github.com/lucasqueiroz/associate-rb)
- [RubyGems](https://rubygems.org/gems/associate_rb)

## What is this Ruby project?

AssociateRB implements Kotlin's `associate` methods to Ruby's `Array`s. It allows you to easily convert an Array into a Hash.

## What are the main difference between this Ruby project and similar ones?

- `Finishing Moves` - Although Finishing Moves includes some methods to convert Arrays into Hashes, it doesn't give you the option to manipulate the Keys and Values at the same time, or add the result to an existing Hash.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.