### PR TITLE
Remove Go Package: Gitrob

### DIFF
--- a/README.md
+++ b/README.md
@@ -1092,7 +1092,6 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 * [BeEF](http://beefproject.com) - BeEF is short for The Browser Exploitation Framework. It is a penetration testing tool that focuses on the web browser.
 * [bundler-audit](https://github.com/rubysec/bundler-audit) - Patch-level security verification for Bundler.
-* [Gitrob](https://github.com/michenriksen/gitrob) - Reconnaissance tool for GitHub organizations.
 * [Metasploit](https://github.com/rapid7/metasploit-framework) - World's most used penetration testing software.
 * [Rack::Attack](https://github.com/kickstarter/rack-attack) - Rack middleware for blocking & throttling abusive requests.
 * [Rack::Protection](https://github.com/sinatra/rack-protection) - Rack middleware for protecting against typical Web attacks.


### PR DESCRIPTION
Since this isn't an addition, I don't know how to follow the pull request template on this one.

I was looking through and saw that Gitrob — albeit being an interesting idea for a package — is not a Ruby tool.

Since this is awesome Ruby, I thought we should also curate as much as we collect