### PR TITLE
Adjusts broken optimist link to Github URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [GLI](https://github.com/davetron5000/gli) - Git-Like Interface Command Line Parser.
 * [Hanami CLI](https://github.com/hanami/cli) - General purpose Command Line Interface (CLI) framework for Ruby.
 * [Main](https://github.com/ahoward/main) - A class factory and DSL for generating command line programs real quick.
-* [Optimist](https://manageiq.github.io/optimist/) - A commandline option parser for Ruby that just gets out of your way.
+* [Optimist](https://github.com/ManageIQ/optimist) - A commandline option parser for Ruby that just gets out of your way.
 * [Rake](https://github.com/ruby/rake) - A make-like build utility for Ruby.
 * [Slop](https://github.com/leejarvis/slop) - Simple Lightweight Option Parsing.
 * [Terrapin](https://github.com/thoughtbot/terrapin) - A small command line library (Formerly Cocaine).


### PR DESCRIPTION
Changes link from broken http://manageiq.org/optimist/ to https://github.com/ManageIQ/optimist