### PR TITLE
Added arel_extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,6 +879,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
   * [Enumerize](https://github.com/brainspec/enumerize) - Enumerated attributes with I18n and ActiveRecord/Mongoid/MongoMapper support.
   * [Goldiloader](https://github.com/salsify/goldiloader) - Automatic ActiveRecord eager loading.
   * [mini_record](https://github.com/DAddYE/mini_record) - ActiveRecord meets DataMapper, with MiniRecord you are be able to write schema inside your models.
+  * [arel_extensions](https://github.com/faveod/arel-extensions) - Extending Arel: more "rubyish" syntax, functions for strings, dates, math... and add native extensions for some DBs.
 * Multi-tenancy
   * [Acts As Tennant](https://github.com/ErwinM/acts_as_tenant) - Add multi-tenancy to a Rails app through a shared database strategy.
   * [Apartment](https://github.com/influitive/apartment) - Multi-tenancy for Rails and ActiveRecord.


### PR DESCRIPTION
## Project
arel_extensions - https://github.com/faveod/arel-extensions

## What is this Ruby project?

Extending Arel: more "rubyish" syntax, functions for strings, dates, math... and add native extensions for some DBs.

```
uat = User.arel_table
User.where(uat[:login] =~ /test/)
User.select((uat[:first_name] + ' ' + uat[:last_name]).as('full_name')).limit(10).map(&:full_name)
((uat[:birthdate] - Date.today) * -1).to_sql
```

## What are the main difference between this Ruby project and similar ones?

I didn't see similar projects, which is why we did it.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.