### PR TITLE
Added rubocop extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,11 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 
 * [prettier](https://github.com/prettier/plugin-ruby) - A prettier plugin for the Ruby language.
 * [RuboCop](https://github.com/rubocop-hq/rubocop) - A static code analyzer, based on the community Ruby style guide.
+  * Extensions
+    * [Rubocop Rails](https://github.com/rubocop-hq/rubocop-rails) - A RuboCop extension focused on enforcing Rails best practices and coding conventions.
+    * [Rubocop Rspec](https://github.com/rubocop-hq/rubocop-rspec) - Code style checking for RSpec files
+    * [Rubocop Performance](https://github.com/rubocop-hq/rubocop-performance) - A RuboCop extension focused on code performance checks.
+
 
 ## Code Highlighting
 


### PR DESCRIPTION
## Project

Rubocop Rails: [Github](https://github.com/rubocop-hq/rubocop-rails) - [RubyGems](https://rubygems.org/gems/rubocop-rails)
Rubocop Performance: [Github](https://github.com/rubocop-hq/rubocop-performance) - [RubyGems](https://rubygems.org/gems/rubocop-performance)
Rubocop Rspec: [Github](https://github.com/rubocop-hq/rubocop-rspec) - [RubyGems](https://rubygems.org/gems/rubocop-rspec)

## What is this Ruby project?

Since the release of Rubocop version 2 some previously integrated supports was moved into other gems (named extensions).
This is a list of basic rubocop extension for (mainly) RoR development. 

## What are the main difference between this Ruby project and similar ones?

is there anyone else doing the same job? 😎 

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.