### PR TITLE
Add Sentimental gem to NLP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -822,6 +822,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [pocketsphinx-ruby](https://github.com/watsonbox/pocketsphinx-ruby) - Ruby speech recognition with Pocketsphinx.
 * [Pragmatic Segmenter](https://github.com/diasks2/pragmatic_segmenter) - Pragmatic Segmenter is a rule-based sentence boundary detection gem that works out-of-the-box across many languages.
 * [Ruby Natural Language Processing Resources](https://github.com/diasks2/ruby-nlp) - Collection of links to Ruby Natural Language Processing (NLP) libraries, tools and software.
+* [Sentimental](https://github.com/7compass/sentimental) - Simple sentiment analysis with Ruby.
 * [Text](https://github.com/threedaymonk/text) - A collection of text algorithms including Levenshtein distance, Metaphone, Soundex 2, Porter stemming & White similarity.
 * [Treat](https://github.com/louismullie/treat) - Treat is a toolkit for natural language processing and computational linguistics in Ruby.
 * [Treetop](https://github.com/cjheath/treetop) - PEG (Parsing Expression Grammar) parser.


### PR DESCRIPTION
Closes #954, which has a :+1: from @markets, which I'm assuming means this gem meets at least preliminary criteria for inclusion.

## Project

Sentimental
[GitHub repo](https://github.com/7compass/sentimental)
[Rubygems page](https://rubygems.org/gems/sentimental)

## What is this Ruby project?

A library for sentiment analysis and n-gram parsing.

## What are the main difference between this Ruby project and similar ones?

Simple interface and intuitive interface.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.