### PR TITLE
Add search_flip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1097,6 +1097,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [SearchCop](https://github.com/mrkamel/search_cop) - Extends your ActiveRecord models to support fulltext search engine like queries via simple query strings and hash-based queries.
 * [Searchkick](https://github.com/ankane/searchkick) - Searchkick learns what your users are looking for. As more people search, it gets smarter and the results get better. It’s friendly for developers - and magical for your users.
 * [Searchlogic](https://github.com/binarylogic/searchlogic) - Object based searching, common named scopes, and other useful named scope tools for ActiveRecord.
+* [search_flip](https://github.com/mrkamel/search_flip) - Full-Featured ElasticSearch Ruby Client with a Chainable DSL.
 * [Sunspot](https://github.com/sunspot/sunspot) - A Ruby library for expressive, powerful interaction with the Solr search engine.
 * [textacular](https://github.com/textacular/textacular) - Exposes full text search capabilities from PostgreSQL, and allows you to declare full text indexes. Textacular extends ActiveRecord with named_scope methods making searching easy and fun!
 * [Thinking Sphinx](https://github.com/pat/thinking-sphinx) - A library for connecting ActiveRecord to the Sphinx full-text search tool.


### PR DESCRIPTION
## search_flip

https://github.com/mrkamel/search_flip

## What is this Ruby project?

A high level elasticsearch ruby client with a powerful chainable API and minimal dependencies

## What are the main differences between this Ruby project and similar ones?

Similar great gems are searchkick, elasticsearch-ruby and chewy, but

* search_flip has a chainable DSL (in contrast to searchkick and elasticsearch-ruby)
* its powerful DSL makes nested aggregations super easy
* supports elasticsearch 1.x up to 7.x
* has minimal dependencies (httprb, oj and hashie only)