### PR TITLE
Add tapping_device

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [pry-rails](https://github.com/rweng/pry-rails) - Avoid repeating yourself, use pry-rails instead of copying the initializer to every rails project. This is a small gem which causes rails console to open pry. It therefore depends on pry.
 * [Rails Footnotes](https://github.com/josevalim/rails-footnotes) - Rails footnotes displays footnotes in your application for easy debugging, such as sessions, request parameters, cookies, filter chain, routes, queries, etc.
 * [Seeing Is Believing](https://github.com/JoshCheek/seeing_is_believing) - Displays the results of every line of code in your file.
+* [tapping_device](https://github.com/st0012/tapping_device) - A tool that allows you to inspect your program from an Object's perspective.
 * [Xray](https://github.com/brentd/xray-rails) - A development tool that reveals your UI's bones.
 
 ## Decorators


### PR DESCRIPTION
## Project

Name: tapping_device
Url: https://github.com/st0012/tapping_device
Blog Posts:
- [Debug Rails issues effectively with tapping_device](https://dev.to/st0012/debug-rails-issues-effectively-with-tappingdevice-c7c)
- [Want to know more about your Rails app? Tap on your objects!](https://dev.to/st0012/want-to-know-more-about-your-rails-app-tap-on-your-objects-bd3)

## What is this Ruby project?

[tapping_device](https://github.com/st0012/tapping_device) is a tool that allows users to track certain events happen on a specific object (like method calls). This means a user can observe its program from a certain object's perspective. It's helpful for debugging purposes or understand an unfamiliar codebase.

## What are the main difference between this Ruby project and similar ones?

AFAIK, there's no similar project at the moment.
