### PR TITLE
Add cache_crispies gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 
 * [ActiveModel::Serializers](https://github.com/rails-api/active_model_serializers) - JSON serialization of objects.
 * [Blanket](https://github.com/inf0rmer/blanket) - A dead simple API wrapper.
+* [cache_crispies](https://github.com/codenoble/cache-crispies) - Speedy Rails JSON serialization with built-in caching.
 * [Crepe](https://github.com/crepe/crepe) - The thin API stack.
 * [Fast JSON API](https://github.com/Netflix/fast_jsonapi) - A lightning fast JSON:API serializer for Ruby Objects.
 * [Grape](http://www.ruby-grape.org) - An opinionated micro-framework for creating REST-like APIs in Ruby.


### PR DESCRIPTION
## Project

**cache_crispies**
https://github.com/codenoble/cache-crispies
https://rubygems.org/gems/cache_crispies
https://codenoble.com/blog/introducing-cache-crispies/

## What is this Ruby project?

A Rails JSON serialization gem that focuses on performance with fast render times, bulit-in caching and a simple, readable DSL.

## What are the main difference between this Ruby project and similar ones?

This project is focused on performance both in it's basic render times and in the fact that it has built-in caching. Also, it doesn't force any particular JSON standard like JSON:API, as many other popular serializers do.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.