### PR TITLE
Add Pathway gem to Abstraction libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Interactor](https://github.com/collectiveidea/interactor) - Interactor provides a common interface for performing complex interactions in a single request.
 * [Light Service](https://github.com/adomokos/light-service) - Series of Actions with an emphasis on simplicity.
 * [Mutations](https://github.com/cypriss/mutations) - Compose your business logic into commands that sanitize and validate input.
+* [Pathway](https://github.com/pabloh/pathway) - Define your business logic in simple steps.
 * [Rails Event Store (RES)](https://github.com/RailsEventStore/rails_event_store) - A library for publishing, consuming, storing and retrieving events. It's your best companion for going with an event-driven architecture for your Rails application.
 * [Responders](https://github.com/plataformatec/responders) - A set of Rails responders to dry up your application.
 * [Surrounded](https://github.com/saturnflyer/surrounded) - Encapsulated related objects in a single system to add behavior during runtime. Extensible implementation of DCI.


### PR DESCRIPTION
## Project

Pathway

https://github.com/pabloh/pathway
https://rubygems.org/gems/pathway

## What is this Ruby project?

Pathway helps you separate your business logic from the rest of your application; regardless if is an HTTP backend, a background processing daemon, etc. The main concept Pathway relies upon to build domain logic modules is the operation, this important concept will be explained in detail the following sections.

## What are the main difference between this Ruby project and similar ones?

- Is lightweight 
- Extensible (by the use of plugins)
- Avoid unnecessary dependencies (only has 2)
- Keeps the core classes clean from monkey patching 

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.