### PR TITLE
add actionview-component

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 ## Abstraction
 
 * [ActiveInteraction](https://github.com/orgsync/active_interaction) - Manage application specific business logic.
+* [ActionView::Component](https://github.com/github/actionview-component) - View components for Rails.
 * [Apotomo](https://github.com/apotonick/apotomo) - Based on Cells, Apotomo gives you widgets and encapsulation, bubbling events, AJAX page updates, rock-solid testing and more.
 * [Cells](https://github.com/trailblazer/cells) - View Components for Rails.
 * [Decent Exposure](https://github.com/hashrocket/decent_exposure) - A helper for creating declarative interfaces in controllers.


### PR DESCRIPTION
## Project

https://github.com/github/actionview-component
https://www.ruby-toolbox.com/projects/actionview-component
https://rubygems.org/gems/actionview-component/

## What is this Ruby project?

ActionView::Component is a framework for building view components in Rails.

ActionView::Components are Ruby classes that are used to render views. They take data as input and return output-safe HTML. Think of them as an evolution of the presenter/decorator/view model pattern, inspired by React Components.

## What are the main difference between this Ruby project and similar ones?

ActionView::Component is similar to other view component libraries, but is specifically designed for tight conceptual integration into Rails. It is an extraction from the GitHub monolith.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.