### PR TITLE
Add ActiveRecord Where Assoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -891,6 +891,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
   * [ferry](https://github.com/cmu-is-projects/ferry) - A ruby gem for easy data transfer.
 * Misc
   * [ActiveRecord::Turntable](https://github.com/drecom/activerecord-turntable) - A database sharding extension for ActiveRecord.
+  * [ActiveRecord Where Assoc](https://github.com/MaxLap/activerecord_where_assoc) - Filter ActiveRecord queries based on associations (using where EXISTS).
   * [ActiveValidators](https://github.com/franckverrot/activevalidators) - An exhaustive collection of off-the-shelf and tested ActiveModel/ActiveRecord validations.
   * [DeepPluck](https://github.com/khiav223577/deep_pluck) - Allow you to pluck attributes from nested associations without loading a bunch of records.
   * [Enumerize](https://github.com/brainspec/enumerize) - Enumerated attributes with I18n and ActiveRecord/Mongoid/MongoMapper support.


### PR DESCRIPTION
## Project

ActiveRecord Where Assoc
https://github.com/MaxLap/activerecord_where_assoc
https://rubygems.org/gems/activerecord_where_assoc

Intoduction to the gem: https://github.com/MaxLap/activerecord_where_assoc/blob/master/INTRODUCTION.md

## What is this Ruby project?

An extension for ActiveRecord to be able to filter your queries based on your associations. It uses where EXISTS, which is SQL's proper way of doing this.

## What are the main difference between this Ruby project and similar ones?

The only alternative doesn't support all of the cases that this gem does and is not as powerful.

ActiveRecord's built-in ways of doing this are riddled with traps. Here is a whole [document](https://github.com/MaxLap/activerecord_where_assoc/blob/master/ALTERNATIVES_PROBLEMS.md) about it.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.