### PR TITLE
Add gitignore-cli tool for CLI Utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [colorize](https://github.com/fazibear/colorize) - Extends String class or add a ColorizedString with methods to set text color, background color and text effects.
 * [colorls](https://github.com/athityakumar/colorls) - Beautifies the `ls` command, with color and font-awesome icons.
 * [formatador](https://github.com/geemus/formatador) - STDOUT text formatting.
+* [gitignore-cli](https://github.com/dvinciguerra/gitignore-cli) - A ruby cli tool that use gitignore.io to generate your gitignore files
 * [Paint](https://github.com/janlelis/paint) - Simple and fast way to set ANSI terminal colors.
 * [Pastel](https://github.com/peter-murach/pastel) - Terminal output styling with intuitive and clean API.
 * [Ru](https://github.com/tombenner/ru) - Ruby in your shell.


### PR DESCRIPTION
## Project

### gitignore-cli

* GitHub - [https://github.com/dvinciguerra/gitignore-cli](https://github.com/dvinciguerra/gitignore-cli)

* RubyGems - [https://rubygems.org/gems/gitignore-cli](https://rubygems.org/gems/gitignore-cli)


## What is this Ruby project?

The `gitignore-cli` is a simple tool that help you to create `.gitignore` files based on excellent `gitignore.io` web tool.

It provides a simple way using one line command or a term ui (searching environments) to generate .gitignore files


## What are the main difference between this Ruby project and similar ones?

Enumerate comparisons.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.