### PR TITLE
add view_component

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Responders](https://github.com/plataformatec/responders) - A set of Rails responders to dry up your application.
 * [Surrounded](https://github.com/saturnflyer/surrounded) - Encapsulated related objects in a single system to add behavior during runtime. Extensible implementation of DCI.
 * [Trailblazer](https://github.com/trailblazer/trailblazer) - Trailblazer is a thin layer on top of Rails. It gently enforces encapsulation, an intuitive code structure and gives you an object-oriented architecture.
+* [ViewComponent](https://github.com/github/view_component) - View components for Rails.
 * [Waterfall](https://github.com/apneadiving/waterfall) - A slice of functional programming to chain ruby services and blocks, thus providing a new approach to flow control.
 * [wisper](https://github.com/krisleech/wisper) - A micro library providing Ruby objects with Publish-Subscribe capabilities.
 


### PR DESCRIPTION
## Project

https://github.com/github/view_component
https://www.ruby-toolbox.com/projects/view_component
https://rubygems.org/gems/view_component

Note: this project was recently renamed. The original name was `actionview-component`: https://www.ruby-toolbox.com/projects/actionview-component.

## What is this Ruby project?

ViewComponent is a framework for building view components in Rails.

ViewComponents are Ruby classes that are used to render views. They take data as input and return output-safe HTML. Think of them as an evolution of the presenter/decorator/view model pattern, inspired by React Components.

## What are the main difference between this Ruby project and similar ones?

ViewComponent is similar to other view component libraries, but is specifically designed for tight conceptual integration into Rails. It is an extraction from the GitHub monolith.

It is compatible with the support for 3rd-party component libraries coming in Rails 6.1.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.