### PR TITLE
Add Breezer gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 
 * [Barkeep](https://github.com/ooyala/barkeep) - Barkeep is a fast, fun way to review code. Engineering organizations can use it to keep the bar high.
 * [Brakeman](https://github.com/presidentbeef/brakeman) - A static analysis security vulnerability scanner for Ruby on Rails applications.
+* [Breezer](https://github.com/lambda2/breezer) - Lock your Gemfile dependencies to safe versions.
 * [Cane](https://github.com/square/cane) - Code quality threshold checking as part of your build.
 * [Coverband](https://github.com/danmayer/coverband) - Rack middleware to help measure production code coverage.
 * [Fasterer](https://github.com/DamirSvrtan/fasterer) - Make your Rubies go faster with this command line tool highly inspired by fast-ruby and Sferik's talk at Baruco Conf.


### PR DESCRIPTION
Breezer is a cli to automatically set all your Gemfile dependencies to safe versions.

- https://github.com/lambda2/breezer
- https://rubygems.org/gems/breezer

# What is this Ruby project?
A cli tool to automatically set all your Gemfile dependencies to safe versions by reading at the current `Gemfile.lock`, and prevent disastrous `bundle update`.

# What are the main difference between this Ruby project and similar ones?
Did not find other tools like this.

---
Please help us to maintain this collection by using reactions (👍, 👎) and comments to express your feelings.

