### PR TITLE
Add stackprof and test-prof gems for "Profiler and Optimization"

### DIFF
--- a/README.md
+++ b/README.md
@@ -996,6 +996,8 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Rbkit](https://github.com/code-mancers/rbkit) - profiler for Ruby. With a GUI.
 * [rbspy](https://github.com/rbspy/rbspy) - Sampling profiler for any Ruby process.
 * [ruby-prof](https://github.com/ruby-prof/ruby-prof) - A code profiler for MRI rubies.
+* [stackprof](https://github.com/tmm1/stackprof) - A sampling call-stack profiler for ruby 2.1+.
+* [test-prof](https://github.com/palkan/test-prof) - Ruby Tests Profiling Toolbox
 
 ## QR
 


### PR DESCRIPTION
## Projects

### stackprof
https://github.com/tmm1/stackprof
https://rubygems.org/gems/stackprof/

### test-prof
https://github.com/palkan/test-prof
https://test-prof.evilmartians.io/
https://rubygems.org/gems/test-prof

## What is this Ruby project?

`stackprof` is a profiling gem, like `ruby-prof`, but it allows you to generate html [flame graphs](https://camo.githubusercontent.com/cd1f56caa017a2ff71ca3f6450c3ac8e03eb1272/687474703a2f2f692e696d6775722e636f6d2f45776e647267442e706e67), which I think is way cool. 
`test-prof` is a set of tools that integrates with `ruby-prof` and `stackprof` and makes life easier to analyse profiling output info.
## What are the main difference between this Ruby project and similar ones?

Quite surprised these two weren't included for profiling stack as are very well known gems (or that was my assumption). First one is [supervised by tenderlove](https://github.com/tmm1/stackprof/commits?author=tenderlove) and the second one is sponsored by [Evil Martians](https://evilmartians.com/), which are usual supporters in the ruby community.
Worth to mention, they're still being maintained, which isn't a luck all profiling gems can tell.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.