### PR TITLE
Add git_curate

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 * [ginatra](https://github.com/NARKOZ/ginatra) - A web frontend for Git repositories.
 * [git-auto-bisect](https://github.com/grosser/git-autobisect) - Find the commit that broke master.
+* [git_curate](https://github.com/matt-harvey/git_curate) - Peruse and delete git branches ergonomically.
 * [git_reflow](https://github.com/reenhanced/gitreflow) - An automated quality control workflow for Agile teams.
 * [git-spelunk](https://github.com/osheroff/git-spelunk) - Dig through git blame history.
 * [git-up](https://github.com/aanand/git-up) - Fetch and rebase all locally-tracked remote branches.


### PR DESCRIPTION
## Project

`git_curate`: A tool to take control of your local git branch proliferation.

* Repo: https://github.com/matt-harvey/git_curate
* Rubygems: https://rubygems.org/gems/git_curate

## What is this Ruby project?

`git_curate` is a very simple tool that extends `git` with a `curate` subcommand. This lets you step through your local branches ergonomically, showing basic information about each, and letting you either keep or delete each one as you go. Alternatively, you can run it non-interactively and simply see a readable summary of your local branches.

## What are the main difference between this Ruby project and similar ones?

* You could do something like this with a GUI tool. `git_curate` is for people who don't want to leave the `git` CLI.
* You could write a script to automatically delete every branch satisfying some set of criteria or other. `git_curate` is for people who for various reasons don't want a _carte blanche_ local branch pruning strategy, who want to "manually" decide which branches to keep or delete, but who want to do so quickly and ergonomically.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.