### PR TITLE
add holidays

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [ByStar](https://github.com/radar/by_star) - Find ActiveRecord objects by year, month, fortnight, week and more!
 * [Chronic](https://github.com/mojombo/chronic) - A natural language date/time parser written in pure Ruby.
 * [groupdate](https://github.com/ankane/groupdate) - The simplest way to group temporal data in ActiveRecord, arrays and hashes.
+* [holidays](https://github.com/holidays/holidays) - A collection of Ruby methods to deal with statutory and other holidays.
 * [ice_cube](https://github.com/seejohnrun/ice_cube) - A date recurrence library which allows easy creation of recurrence rules and fast querying.
 * [local_time](https://github.com/basecamp/local_time) - Rails Engine for cache-friendly, client-side local time.
 * [montrose](https://github.com/rossta/montrose) - a simple library for expressing, serializing, and enumerating recurring events in Ruby
@@ -1034,7 +1035,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 ## Robotics
 
-* [Arli](https://github.com/kigster/arli) - Arli is the CLI tool for searching, installing, and packaging Arduino libraries with a project using a YAML-based Arlifile. It's a "Bundler for Arduino Development". 
+* [Arli](https://github.com/kigster/arli) - Arli is the CLI tool for searching, installing, and packaging Arduino libraries with a project using a YAML-based Arlifile. It's a "Bundler for Arduino Development".
 * [Artoo](http://artoo.io) - Next generation robotics framework with support for different platforms: Arduino, Leap Motion, Pebble, Raspberry Pi, etc.
 
 ## RSS


### PR DESCRIPTION
## Project

Holidays
https://github.com/holidays/holidays
https://rubygems.org/gems/holidays

## What is this Ruby project?

Functionality to deal with holidays in Ruby.
Extends Ruby's built-in Date and Time classes and supports custom holiday definition lists.

## What are the main difference between this Ruby project and similar ones?

I didn't find any similar project in the list, and this one is very useful IMO.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.