### PR TITLE
Add cable_ready gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1265,6 +1265,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 ## WebSocket
 
 * [AnyCable](http://anycable.io) – Polyglot replacement for Ruby WebSocket servers with Action Cable protocol.
+* [CableReady](https://github.com/hopsoft/cable_ready) - CableReady completes the ActionCable story and expands the utility of web sockets in your Rails app.
 * [Faye](http://faye.jcoglan.com/ruby.html) - A set of tools for simple publish-subscribe messaging between web clients.
 * [Firehose](https://github.com/firehoseio/firehose) - Build realtime Ruby web applications.
 * [Slanger](https://github.com/stevegraham/slanger) - Open Pusher implementation compatible with Pusher libraries.


### PR DESCRIPTION
CableReady completes the ActionCable story and expands the utility of web sockets in your Rails app.

## Project

* [GitHub](https://github.com/hopsoft/cable_ready)
* [Docs](https://cableready.stimulusreflex.com)
* [Build a real-time Twitter clone in 10 mins with Rails, StimulusReflex and CableReady](https://dev.to/codefund/build-a-real-time-twitter-clone-10-mins-with-rails-and-stimulusreflex-5h5c)


## What is this Ruby project?

CableReady helps you create great real-time user experiences by making it simple to trigger client-side DOM changes from server-side Ruby. It establishes a standard for interacting with the client via ActionCable web sockets. No need for custom JavaScript.

Possible interactions range from updating a single element's value to replacing entire sections of content. You can even dispatch client-side DOM events from the server. Also, updates don't need to be initiated by the user. For example, CableReady can update your UI in response to things happening on the server, such as long running ActiveJobs or activity from API calls and webhooks. It's never been easier to notify users of site wide activity.

**Note:** [StimulusReflex](https://github.com/hopsoft/stimulus_reflex) is built on top of CableReady. 

## What are the main difference between this Ruby project and similar ones?

I don't think there is a similar project in the Ruby ecosystem.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.