### PR TITLE
Simple Scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1016,6 +1016,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [resque-scheduler](https://github.com/resque/resque-scheduler) - A light-weight job scheduling system built on top of Resque.
 * [rufus-scheduler](https://github.com/jmettraux/rufus-scheduler) - Job scheduler for Ruby (at, cron, in and every jobs).
 * [Sidekiq-Cron](https://github.com/ondrejbartas/sidekiq-cron) - A scheduling add-on for Sidekiq.
+* [Simple Scheduler](https://github.com/simplymadeapps/simple_scheduler) - An enhancement for Heroku Scheduler + Sidekiq for scheduling jobs at specific times with a readable YML file.
 * [Whenever](https://github.com/javan/whenever) - A Ruby gem that provides a clear syntax for writing and deploying cron jobs.
 
 ## Scientific


### PR DESCRIPTION
## Project

[Simple Scheduler](https://github.com/simplymadeapps/simple_scheduler), an enhancement for Heroku Scheduler + Sidekiq for scheduling jobs at specific times. [Check out our intro blog post to learn more](http://www.simplymadeapps.com/blog/2017/01/simple-scheduler-schedule-recurring-tasks-to-run-at-any-interval/).

## What is this Ruby project?

Simple Scheduler is a scheduling add-on that is designed to be used with [Sidekiq](http://sidekiq.org) and [Heroku Scheduler](https://elements.heroku.com/addons/scheduler). It gives you the ability to **schedule tasks at any interval** without adding a clock process. Heroku Scheduler only allows you to schedule tasks every 10 minutes, every hour, or every day.

## What are the main difference between this Ruby project and similar ones?

Every option we evaluated seems to have the same flaw: **If your server is down, your job won't run.** With Simple Scheduler, we use Sidekiq's robust scheduling and retrying system to make sure your schedule jobs run, even if the server was down at the moment it should have ran.

Everything is driven from a simple YML file for readability and developer happiness. No crontab knowledge required. ActiveSupport durations FTW!

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.