### PR TITLE
Add puma-pool-usage gem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -955,6 +955,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [bullet](https://github.com/flyerhzm/bullet) - Help to kill N+1 queries and unused eager loading.
 * [Derailed Benchmarks](https://github.com/schneems/derailed_benchmarks) - A series of things you can use to benchmark any Rack based app.
 * [Peek](https://github.com/peek/peek) - Visual status bar showing Rails performance.
+* [puma-pool-usage](https://github.com/simplymadeapps/puma-pool-usage) - Puma plugin to calculate and log your web server pool usage.
 * [rack-mini-profiler](https://github.com/MiniProfiler/rack-mini-profiler) - Profiler for your development and production Ruby rack apps.
 * [Rbkit](https://github.com/code-mancers/rbkit) - profiler for Ruby. With a GUI.
 * [rbspy](https://github.com/rbspy/rbspy) - Sampling profiler for any Ruby process.


### PR DESCRIPTION
## Project

[Puma Pool Usage](https://github.com/simplymadeapps/puma-pool-usage), a Puma plugin that interprets usage statistics for the percentage of your resources under load. Uses Rails to log this statistic. 

## What is this Ruby project?

Inspired by [Tomas Ruzicka](https://github.com/LeZuse) and Heroku's pool usage statistics. Knowing how much of your Puma pool is busy and how much you have available is critical to knowing whether you have enough resources available to handle increases in web server load. 

Look at this neat log:

```
source=PUMA pid=74840 sample#pool_usage=0.8
```

If your web server is fielding no requests, usage will be 0.0 (0%). If every single resource has a request, usage will be 1.0 (100%). If you have a backlog of requests that cannot be processed because no resources are available, usage can be over 100% (like 1.4).

Having this data allows anyone to chart this data for performance, setup alerts, or scale your servers based on it. These are all great idea, but it's beyond the scope of this plugin. This plugin provides the data, what you do with the data is up to you.

## What are the main difference between this Ruby project and similar ones?

Puma pool statistics are provided via the Puma internals. This plugin surfaces them in your logs with an algorithm that takes into account your Puma settings and cluster mode. The closest similar project would be the [barnes gem](https://github.com/heroku/barnes) that does more statistical analysis but works exclusively with Heroku. This gem works on any host running Puma.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.