### PR TITLE
Added Optic

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [RDoc](https://github.com/ruby/rdoc) - RDoc produces HTML and command-line documentation for Ruby projects.
 * [rspec_api_documentation](https://github.com/zipmark/rspec_api_documentation) - Automatically generate API documentation from RSpec.
 * [YARD](http://yardoc.org) - YARD enables the user to generate consistent, usable documentation that can be exported to a number of formats very easily.
+* [Optic](https://github.com/opticdev/optic) - Optic automatically documents and tests your APIs
 
 ## E-Commerce and Payments
 


### PR DESCRIPTION

## Project

Optic automatically documents and tests your APIs.

I think Optic is awesome because its super simple to use and lets you easily add docs to any project. For most api projects, maintaining and creating documentation is a pain, and optic greatly streamlines this process.

Repo: opticdev/optic, Homepage: useoptic.com

Installation via Brew —

    brew install opticdev/optic/api

## What is this Ruby project?

This project integrates seamlessly with Ruby projects like Rails to build documentation for your project

## What are the main difference between this Ruby project and similar ones?

Optic documents changes in behavior — not code — and with just one command, Optic gives you the power of a dedicated API team. Optic automatically documents changes, tests every endpoint, and gives you valuable insight into how your APIs are being used.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.