### PR TITLE
Add blueprinter as API builder library

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 
 * [ActiveModel::Serializers](https://github.com/rails-api/active_model_serializers) - JSON serialization of objects.
 * [Blanket](https://github.com/inf0rmer/blanket) - A dead simple API wrapper.
+* [Blueprinter](https://github.com/procore/blueprinter) - Simple, Fast, and Declarative Serialization Library for Ruby.
 * [Crepe](https://github.com/crepe/crepe) - The thin API stack.
 * [Fast JSON API](https://github.com/Netflix/fast_jsonapi) - A lightning fast JSON:API serializer for Ruby Objects.
 * [Grape](http://www.ruby-grape.org) - An opinionated micro-framework for creating REST-like APIs in Ruby.


### PR DESCRIPTION
## Project

- [Github](https://github.com/procore/blueprinter)
- [RubyGems](https://rubygems.org/gems/blueprinter/versions/0.6.0)

## What is this Ruby project?

Blueprinter is a JSON Object Presenter for Ruby that takes business objects and breaks them down into simple hashes and serializes them to JSON. It can be used in Rails in place of other serializers (like JBuilder or ActiveModelSerializers). It is designed to be simple, direct, and performant.

## What are the main difference between this Ruby project and similar ones?

It heavily relies on the idea of views which, similar to Rails views, are ways of predefining output for data in different contexts.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.