### PR TITLE
Add image_processing gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,13 +709,13 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 ## Image Processing
 
+* [ImageProcessing](https://github.com/janko/image_processing) - High-level image processing wrapper for libvips and ImageMagick/GraphicsMagick
 * [MiniMagick](https://github.com/minimagick/minimagick) - A ruby wrapper for ImageMagick or GraphicsMagick command line.
 * [Phasion](https://github.com/westonplatter/phashion) - Ruby wrapper around pHash, the perceptual hash library for detecting duplicate multimedia files.
 * [PSD.rb](https://github.com/layervault/psd.rb) - Parse Photoshop files in Ruby with ease.
 * [RMagick](https://github.com/rmagick/rmagick) - RMagick is an interface between Ruby and ImageMagick.
 * [ruby-vips](https://github.com/jcupitt/ruby-vips) - A binding for the libvips image processing library.
 * [Skeptick](https://github.com/maxim/skeptick) - Skeptick is an all-purpose DSL for building and running ImageMagick commands.
-* [ImageProcessing](https://github.com/janko/image_processing) - High-level image processing wrapper for libvips and ImageMagick/GraphicsMagick
 
 ## Implementations/Compilers
 

--- a/README.md
+++ b/README.md
@@ -715,6 +715,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [RMagick](https://github.com/rmagick/rmagick) - RMagick is an interface between Ruby and ImageMagick.
 * [ruby-vips](https://github.com/jcupitt/ruby-vips) - A binding for the libvips image processing library.
 * [Skeptick](https://github.com/maxim/skeptick) - Skeptick is an all-purpose DSL for building and running ImageMagick commands.
+* [ImageProcessing](https://github.com/janko/image_processing) - High-level image processing wrapper for libvips and ImageMagick/GraphicsMagick
 
 ## Implementations/Compilers
 


### PR DESCRIPTION
## Project
ImageProcessing
https://github.com/janko/image_processing
https://rubygems.org/gems/image_processing

## What is this Ruby project?
ImageProcessing provides higher-level image processing helpers that are commonly needed when handling image uploads. This gem can process images with either ImageMagick/GraphicsMagick or libvips libraries.

## What are the main difference between this Ruby project and similar ones?
ImageProcessing's goal is to have a single gem that contains all the helper methods needed to resize and process images. Currently, existing attachment gems (like Paperclip, CarrierWave, Refile, Dragonfly, ActiveStorage, and others) implement their own custom image helper methods. But this isn't very DRY.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.