### PR TITLE
add pubnub-publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -786,7 +786,8 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 * [dryrun](https://github.com/cesarferreira/dryrun) - Try any Android library on your smartphone directly from the command line.
 * [fastlane](https://github.com/fastlane/fastlane) - Connect all iOS deployment tools into one streamlined workflow.
-* [PubNub](https://github.com/pubnub/ruby) - Real-time Push Service in the Cloud.
+* [Pubnub](https://github.com/pubnub/ruby) - Real-time Push Service in the Cloud.
+* [pubnub-publisher](https://github.com/mattetti/pubnub-publisher) - The simplest PubNub gem possible to simply publish events
 * [Ruboto](https://github.com/ruboto/ruboto) - A platform for developing full stand-alone apps for Android using the Ruby language and libraries.
 * [RubyMotion](http://www.rubymotion.com) - A revolutionary toolchain that lets you quickly develop and test full-fledged native iOS and OS X applications for iPhone, iPad, Mac and Android.
 * [Ruby Push Notifications](https://github.com/calonso/ruby-push-notifications) - iOS, Android and Windows Phone Push notifications made easy.


### PR DESCRIPTION
## pubnub-publisher

- https://rubygems.org/gems/pubnub-publisher/versions/1.0.1
- https://github.com/mattetti/pubnub-publisher

## What is this Ruby project?

A Ruby publisher gem for PubNub (for those who only care about publishing from Ruby)

## What are the main difference between this Ruby project and similar ones?

This gem is a addon for the official PubNub's Ruby gem. Unlike the official gem, this doesn't have any dependencies, it relies entirely on Ruby's stdlib.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.