### PR TITLE
Add acts_as_api gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 ## API Builder and Discovery
 
 * [ActiveModel::Serializers](https://github.com/rails-api/active_model_serializers) - JSON serialization of objects.
+* [Acts_As_Api](https://github.com/fabrik42/acts_as_api) - Easy And Fun, in creating XML/JSON responses in Rails 3,4,5 and 6.
 * [Blanket](https://github.com/inf0rmer/blanket) - A dead simple API wrapper.
 * [Blueprinter](https://github.com/procore/blueprinter) - Simple, Fast, and Declarative Serialization Library for Ruby.
 * [Crepe](https://github.com/crepe/crepe) - The thin API stack.


### PR DESCRIPTION
## Acts_As_Api

- https://rubygems.org/gems/acts_as_api/versions/0.4.2

- https://github.com/fabrik42/acts_as_api

## What is this Ruby project?

Describe features.

- DRY templates for your api responses

- Ships with support for ActiveRecord and Mongoid

- Plays very well together with client libs like Backbone.js, RestKit (iOS) or gson (Android).

- Easy but very flexible syntax for defining the templates

- XML, JSON and JSON-P support out of the box, easy to extend

- Minimal dependecies (you can also use it without Rails)

- Supports multiple api rendering templates per model. This is especially useful for API versioning or for example for private vs. public access points to a user’s profile.

## What are the main difference between this Ruby project and similar ones?

- Easy to use :heart: 

- Supports multiple api rendering templates per model .

- Easy Integrations with templates .

- Ease of creating and modifying templates :heart_eyes: 

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.