### PR TITLE
Add Truemail gem to Email section

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [premailer-rails](https://github.com/fphilipe/premailer-rails) - CSS styled emails without the hassle.
 * [Roadie](https://github.com/Mange/roadie) - Roadie tries to make sending HTML emails a little less painful by inlining stylesheets and rewriting relative URLs for you inside your emails.
 * [Sup](https://github.com/sup-heliotrope/sup) - A curses threads-with-tags style email client.
+* [Truemail](https://truemail-rb.org/truemail-gem) - Configurable framework agnostic plain Ruby email validator/verifier. Verify email via Regex, DNS and SMTP. Be sure that email address valid and exists.
 
 ## Encryption
 


### PR DESCRIPTION
## Project

[![Truemail](https://truemail-rb.org/assets/images/truemail_logo.png)](https://truemail-rb.org)

Configurable framework agnostic plain Ruby 📨 email validator. Helps to validate/verify emails via Regex, DNS and SMTP.

**Project page:** https://truemail-rb.org/truemail-gem
**GitHub:** https://github.com/rubygarage/truemail
**RubyGems:** https://rubygems.org/gems/truemail

## What is this Ruby project?

1. Configurable layer-designed validator
2. Minimal runtime dependencies
3. Supporting of internationalized emails (EAI)
4. Whitelist/blacklist validation's layers
5. Simple SMTP debugger
6. Event logger
7. Host auditor tools (helps to detect common host problems interfering to proper email verification)
8. JSON serializers for audition and validation results

## What are the main difference between this Ruby project and similar ones?

It's OOAK email vaildator in a Ruby World.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.