### PR TITLE
Changing thredded to GH link - site is down.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1107,7 +1107,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Mailboxer](https://github.com/mailboxer/mailboxer) - A private message system for Rails applications.
 * [Mastodon](https://github.com/Gargron/mastodon) - A GNU Social-compatible microblogging server.
 * [Social Shares](https://github.com/Timrael/social_shares) - A gem to check how many times url was shared in social networks.
-* [Thredded](https://thredded.org) - Rails 4.2+ forums/messageboards engine. Its goal is to be as simple and feature rich as possible.
+* [Thredded](https://github.com/thredded/thredded) - Rails 4.2+ forums/messageboards engine. Its goal is to be as simple and feature rich as possible.
 
 ## Spreadsheets and Documents
 


### PR DESCRIPTION
Hey @markets 

just fixing a link to GitHub as the thredded site is down.

Cheers!