### PR TITLE
Add railsnew.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1002,6 +1002,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Hobo](https://github.com/Hobo/hobo) - The web app builder for Rails.
 * [orats](https://github.com/nickjj/orats) - Opinionated rails application templates.
 * [Rails Composer](https://github.com/RailsApps/rails-composer) - The Rails generator on steroids for starter apps.
+* [railsnew.io](https://railsnew.io) - The simplest way to generate a new Rails app with (or without!) all the bells and whistles.
 * [Raygun](https://github.com/carbonfive/raygun) - Builds applications with the common customization stuff already done.
 * [Suspenders](https://github.com/thoughtbot/suspenders) - Suspenders is the base Rails application used at thoughtbot.
 


### PR DESCRIPTION
## Project

As requested by @markets in #1016

https://railsnew.io

Closes #1016 

## What is this Ruby project?

 The simplest way to generate a new Rails app with (or without!) all the bells and whistles.

## What are the main difference between this Ruby project and similar ones?

See #1016 

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.