### PR TITLE
Add Bridgetown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1130,6 +1130,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 ## Static Site Generation
 
+* [Bridgetown](https://github.com/bridgetownrb/bridgetown) - A Webpack-aware, Ruby-powered static site generator for the modern Jamstack era.
 * [High Voltage](https://github.com/thoughtbot/high_voltage) - Easily include static pages in your Rails app.
 * [Jekyll](https://jekyllrb.com) - Transform your plain text into static websites and blogs.
   * [Awesome Jekyll](https://github.com/planetjekyll/awesome-jekyll) - A collection of awesome Jekyll tools, plugins, themes, guides and much more.


### PR DESCRIPTION
## Project

Website: https://www.bridgetownrb.com
Repo: https://github.com/bridgetownrb/bridgetown
Docs: https://www.bridgetownrb.com/docs/

## What is this Ruby project?

> Bridgetown is a Webpack-aware, Ruby-powered static site generator for the modern Jamstack era. Bridgetown takes your content, API data, and frontend assets; renders templates in Markdown, Liquid, ERB, and many other formats; and exports a complete website ready to be served by fast Jamstack services like Netlify or traditional web servers like Nginx.

## What are the main difference between this Ruby project and similar ones?

See https://www.bridgetownrb.com/about/

> Bridgetown started life as a fork of the granddaddy of static site generators, Jekyll.

> But as the concepts of modern static site generation and the Jamstack came to the forefront, a whole new generation of tools rose up, like Hugo, Eleventy, Gatsby, and many more. In the face of all this new competition, Jekyll chose to focus on maintaining extensive backwards-compatibility and a paired-down feature set—noble goals for an open source project generally speaking, but ones that were at odds with meaningful portions of the web developer community.

> So in March 2020, Portland-based web studio Whitefusion started on Bridgetown, a fork of Jekyll with a brand new set of project goals and a future roadmap.

> It’s early days yet, but our goal is to keep adding new features at a steady and predictable pace, grow the open source community around the project, and ensure a lively future for a top-tier Ruby-based static site generator moving forward.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.