### PR TITLE
Add ruby-spellchecker

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,6 +814,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [pocketsphinx-ruby](https://github.com/watsonbox/pocketsphinx-ruby) - Ruby speech recognition with Pocketsphinx.
 * [Pragmatic Segmenter](https://github.com/diasks2/pragmatic_segmenter) - Pragmatic Segmenter is a rule-based sentence boundary detection gem that works out-of-the-box across many languages.
 * [Ruby Natural Language Processing Resources](https://github.com/diasks2/ruby-nlp) - Collection of links to Ruby Natural Language Processing (NLP) libraries, tools and software.
+* [ruby-spellchecker](https://github.com/omohokcoj/ruby-spellchecker) - English spelling and grammar checker that can be used for autocorrection.
 * [Sentimental](https://github.com/7compass/sentimental) - Simple sentiment analysis with Ruby.
 * [Text](https://github.com/threedaymonk/text) - A collection of text algorithms including Levenshtein distance, Metaphone, Soundex 2, Porter stemming & White similarity.
 * [Treat](https://github.com/louismullie/treat) - Treat is a toolkit for natural language processing and computational linguistics in Ruby.


### PR DESCRIPTION
## Project

ruby-spellchecker [https://github.com/omohokcoj/ruby-spellchecker](https://github.com/omohokcoj/ruby-spellchecker)
RubyGems: https://rubygems.org/gems/ruby-spellchecker

## What is this Ruby project?

It helps to eliminate common spelling and grammar errors from the text (to prepare it for NLP for instance).

## What are the main difference between this Ruby project and similar ones?

Other ruby spellchecking gems are quite outdated and not maintained. Many of them use hunspell-ffi to check all words from the text against existing English dictionaries and to suggest corrections based on jaro/levenshtein distance. Hunspell's approach can produce many false positives and requires shared libraries to be installed. This gem uses a large list of common errors collected from various open sources so it doesn't produce false positives and can be used for autocorrection. Also, it's written in pure ruby.