### PR TITLE
Add attr-gather gem to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 ## Data Processing and ETL
 
+* [attr-gather](https://github.com/ianks/attr-gather) - A gem for creating workflows that "enhance" entities with extra attributes. At a high level, attr-gather provides a process to fetch information from many data sources (such as third party APIs, legacy databases, etc.) in a fully parallelized fashion.
 * [CSV Reader](https://github.com/csvreader/csvreader) - A modern tabular data (line-by-line records) reader supports "classic" CSV but also CSV Numerics, `CSV <3 JSON`, `CSV <3 YAML`, tab, space or fixed width fields (FWF) and many more flavors and dialects.
 * [Kiba](http://www.kiba-etl.org) - A lightweight data processing / ETL framework for Ruby.
 * [ruby-stemmer](https://github.com/aurelian/ruby-stemmer) - It Provides Snowball algorithm for stemming purposes.


### PR DESCRIPTION
## Project

Name: `attr-gather`
GitHub: https://github.com/ianks/attr-gather
RubyGems: https://rubygems.org/gems/attr-gather

## What is this Ruby project?

[attr-gather](https://github.com/ianks/attr-gather) - A gem for creating workflows that "enhance" entities with extra attributes. At a high level, [attr-gather](https://github.com/ianks/attr-gather) provides a process to fetch information from many data sources (such as third party APIs, legacy databases, etc.) in a fully parallelized fashion.

- Offers DSL for defining workflows and merging the results from each task
- Execution engine optimally parallelizes the execution of the workflow dependency graph
- Easily testable
- Ability to filter out bad data using schemas with [dry-validation](https://dry-rb.org/gems/dry-validation)

## What are the main difference between this Ruby project and similar ones?

- Operates on a single entity rather than a list, so easily can be adopted in existing systems
- Focuses on the "fetching" and filtering of data solely, and not transformation or storage
- Fully parallel execution engine
- Focuses on having a clean PORO interface to make testing simple
- Provides a declarative interface for merging results from many sources (APIs, legacy databases, etc.) which allows for prioritization

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.