### PR TITLE
Add overmind to list of Procfile managers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -956,6 +956,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Bluepill](https://github.com/bluepill-rb/bluepill) - Simple process monitoring tool.
 * [Eye](https://github.com/kostya/eye) - Process monitoring tool. Inspired from Bluepill and God.
 * [Foreman](https://github.com/ddollar/foreman) - Manage Procfile-based applications.
+* [Overmind](https://github.com/DarthSim/overmind) - Manage Procfile-based applications, with the ability to connect to any process via tmux..
 * [God](https://github.com/mojombo/god) - An easy to configure, easy to extend monitoring framework written in Ruby.
 * [Health Monitor Rails](https://github.com/lbeder/health-monitor-rails) - A mountable Rails plug-in to check health of services (Database, Cache, Sidekiq, Redis, e.t.c.) used by the Rails app.
 * [Procodile](https://github.com/adamcooke/procodile) - Run processes in the background (and foreground) on Mac & Linux from a Procfile.


### PR DESCRIPTION
## Project

Overmind – https://github.com/DarthSim/overmind

## What is this Ruby project?

Overmind is a Procfile runner that runs on tmux

## What are the main difference between this Ruby project and similar ones?

Compared to it's competitor, foreman, Overmind enables running Procfiles on tmux. This gives it the ability to more easily start, stop, restart and kill individual processes, as well as connecting to each process for the ability to debug using something like `pry`.

I personally moved over from foreman to Overmind in the past year, and have loved it so far. Can't find a fault - only improvements on top of foreman.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.