### PR TITLE
Technical/Add DnsMock to Testing section, Mock subsection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1182,6 +1182,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
   * [Forgery](https://github.com/sevenwire/forgery) - Easy and customizable generation of forged data.
 * Mock
   * [ActiveMocker](https://github.com/zeisler/active_mocker) - Generate mocks from ActiveRecord models for unit tests that run fast because they don’t need to load Rails or a database.
+  * [DnsMock](https://github.com/mocktools/ruby-dns-mock) - Ruby DNS mock. Mimic any DNS records for your test environment and even more.
   * [DuckRails](https://github.com/iridakos/duckrails) - Tool for mocking API endpoints quickly & dynamically.
   * [TestXml](https://github.com/alovak/test_xml) - TestXml is a small extension for testing XML/HTML.
   * [WebMock](https://github.com/bblimke/webmock) - Library for stubbing and setting expectations on HTTP requests.


### PR DESCRIPTION
## Project

💎 Ruby DNS mock. Mimic any DNS records for your test environment and even more.

**GitHub:** https://github.com/mocktools/ruby-dns-mock
**RubyGems:** https://rubygems.org/gems/dns_mock

## What is this Ruby project?

1. Ability to mimic any DNS records (`A`, `AAAA`, `CNAME`, `MX`, `NS`, `PTR`, `SOA` and `TXT`)
2. Zero runtime dependencies
3. Lightweight UDP DNS mock server with dynamic/manual port assignment
4. Test framework agnostic (it's PORO, so you can use it outside of `RSpec`, `Test::Unit` or `MiniTest`)
5. Simple and intuitive DSL
6. `RSpec` out of the box support

## What are the main difference between this Ruby project and similar ones?

The first flexible DNS mocking tool for Ruby 💎

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.