### PR TITLE
Update RubyGnome

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,7 +685,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 * [Glimmer](https://github.com/AndyObtiva/glimmer) - Ruby DSL for SWT
 * [qtbindings](https://github.com/ryanmelt/qtbindings) - Allows the QT Gui toolkit to be used from Ruby.
-* [RubyGnome2](http://ruby-gnome2.sourceforge.jp/) - Ruby language bindings for the GNOME 2.0 development environment.
+* [Ruby-GNOME](https://github.com/ruby-gnome/ruby-gnome) - Ruby language bindings for the GNOME development environment.
 * [Shoes](http://shoesrb.com) - Shoes makes building little graphical programs for Mac, Windows, and Linux super simple.
 
 ## HTML/XML Parsing


### PR DESCRIPTION
* Ruby-GNOME2 project has been renamed to Ruby-GNOME. (Because the version number of GNOME keeps going up.)
* Change link to GitHub. The information on the official site is outdated; GitHub is a more appropriate link.