### PR TITLE
Add `accept_language`

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 ## HTTP Clients and tools
 
+* [Accept Language](https://github.com/cyril/accept_language.rb) - A tiny library for parsing the `Accept-Language` header from browsers (as defined in [RFC 2616](https://datatracker.ietf.org/doc/html/rfc2616#section-14.4)).
 * [excon](https://github.com/excon/excon) - Usable, fast, simple Ruby HTTP 1.1. It works great as a general HTTP(s) client and is particularly well suited to usage in API clients.
 * [Faraday](https://github.com/lostisland/faraday) - an HTTP client lib that provides a common interface over many adapters (such as Net::HTTP) and embraces the concept of Rack middleware when processing the request/response cycle.
 * [Device Detector](https://github.com/podigee/device_detector) - A precise and fast user agent parser and device detector, backed by the largest and most up-to-date user agent database.


### PR DESCRIPTION
# Accept Language

## Project

* GitHub: https://github.com/cyril/accept_language.rb
* Gem: https://rubygems.org/gems/accept_language

## What is this Ruby project?

A tiny library for parsing the `Accept-Language` header from browsers (as defined in [RFC 2616](https://datatracker.ietf.org/doc/html/rfc2616#section-14.4)).

### Example

```ruby
AcceptLanguage.parse("da, en;q=0.8, ug;q=0.9").match("en-GB", "ug-CN")  # => "ug-CN"
```

## What are the main difference between this Ruby project and similar ones?

This tool is:

* thread-safe
* well-maintained
* really minimalist
* handle super tricky use-cases
* case, type and language-agnostic
* Rails, Rack & I18n independent
* BCP-47 support
* MIT licensed

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.