### PR TITLE
Add ruby-clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1048,6 +1048,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [que-scheduler](https://github.com/hlascelles/que-scheduler) - A lightweight cron scheduler for the async job worker Que.
 * [resque-scheduler](https://github.com/resque/resque-scheduler) - A light-weight job scheduling system built on top of Resque.
 * [rufus-scheduler](https://github.com/jmettraux/rufus-scheduler) - Job scheduler for Ruby (at, cron, in and every jobs).
+* [ruby-clock](https://github.com/jjb/ruby-clock) - A job scheduler which runs jobs each in their own thread in a persistent process.
 * [Sidekiq-Cron](https://github.com/ondrejbartas/sidekiq-cron) - A scheduling add-on for Sidekiq.
 * [Simple Scheduler](https://github.com/simplymadeapps/simple_scheduler) - An enhancement for Heroku Scheduler + Sidekiq for scheduling jobs at specific times with a readable YML file.
 * [Whenever](https://github.com/javan/whenever) - A Ruby gem that provides a clear syntax for writing and deploying cron jobs.


### PR DESCRIPTION
## Project

Source: https://github.com/jjb/ruby-clock
RubyGems: https://rubygems.org/gems/ruby-clock

## What is this Ruby project?

a scheduler which can replace cron. runs jobs in a persistent process, each in their own thread

## What are the main difference between this Ruby project and similar ones?

1. based on venerable rufus for scheduling mechanics
2. runs jobs in persistent process
3. easy to configure to be a good citizen running in environments like heroku

