### PR TITLE
Add Vite Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Sprockets](https://github.com/rails/sprockets) - Rack-based asset packaging system.
 * [Torba](https://github.com/torba-rb/torba) - Bower-less bundler for Sprockets.
 * [Webpacker](https://github.com/rails/webpacker) - Use Webpack to manage app-like JavaScript modules in Rails.
+* [Vite Ruby](https://github.com/elmassimo/vite_ruby) - Use Vite.js as a modern assets pipeline in Ruby and Rails apps.
 
 ## Authentication and OAuth
 


### PR DESCRIPTION
[Vite Ruby]: https://github.com/elmassimo/vite_ruby
[website]: https://vite-ruby.netlify.app/
[vite.js]: https://vitejs.dev/

## Vite Ruby

- [Repo][Vite Ruby]
- [Website]

## What is Vite Ruby?

An umbrella project with libraries that allow to easily integrate [Vite.js] in your favourite Ruby framework, such as Rails, Hanami, Padrino, and even [Jekyll sites](https://jekyll-vite.netlify.app/).

For example, `vite-rails` provides a complete setup for Rails applications, making it a suitable alternative to sprockets or webpacker.

## What are the main difference between this and similar tools like Webpacker or Sprockets?

Vite Ruby enables using Vite.js which—unlike Webpack—does not bundle code during development, which means the dev server is extremely fast to start, and changes are updated instantly.

In production, Vite.js bundles your code using Rollup.js which provides tree-shaking, lazy-loading, and common chunk splitting out of the box, to achieve optimal loading performance.

It also provides great defaults, and is easier to configure than similar tools like Webpack.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.