### PR TITLE
Add `r_spec-clone`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1190,6 +1190,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
   * [minitest](https://github.com/seattlerb/minitest) - minitest provides a complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking.
   * [Mocha](https://github.com/freerange/mocha) - Mocha is a mocking and stubbing library for Ruby.
   * [RR](https://github.com/rr/rr) - A test double framework that features a rich selection of double techniques and a terse syntax.
+  * [RSpec clone](https://github.com/cyril/r_spec-clone.rb) - A minimalist RSpec clone with all the essentials.
   * [shoulda-matchers](https://github.com/thoughtbot/shoulda-matchers) - Provides Test::Unit- and RSpec-compatible one-liners that test common Rails functionality. These tests would otherwise be much longer, more complex, and error-prone.
   * [Spinach](https://github.com/codegram/spinach) - Spinach is a high-level BDD framework that leverages the expressive Gherkin language (used by Cucumber) to help you define executable specifications of your application or library's acceptance criteria.
   * [Test::Unit](http://test-unit.github.io) - Test::Unit is a xUnit family unit testing framework for Ruby.


### PR DESCRIPTION
# RSpec clone

* API doc: https://rubydoc.info/gems/r_spec-clone
* Gem: https://rubygems.org/gems/r_spec-clone
* GitHub: https://github.com/cyril/r_spec-clone.rb
* Home page: https://r-spec.dev/

## What is this Ruby project?

A minimalist reimplementation of RSpec to enforce the guidelines and best practices outlined in the community (https://rspec.rubystyle.guide/). This clone includes most of RSpec’s DSL to express expected outcomes with no magical powers:

[![RSpec clone demo](https://asciinema.org/a/422210.svg)](https://asciinema.org/a/422210?autoplay=1&speed=2)

## What are the main difference between this clone and the original RSpec?

* There is no option to activate monkey-patching.
* It does not rely on hacks such as `at_exit` hook (https://blog.arkency.com/2013/06/are-we-abusing-at-exit/) to trigger the tests.
* Malicious _actual values_ cannot hack results (https://asciinema.org/a/423547?autoplay=1&speed=2).
* If no `subject` has been explicitly determined, none is defined.
* If no described class is set, `described_class` is undefined instead of `nil`.
* Expectations cannot be added inside a `before` block.
* Arbitrary helper methods (https://relishapp.com/rspec/rspec-core/v/3-10/docs/helper-methods/arbitrary-helper-methods) are not exposed to examples.
* The `let` method defines a helper method rather than a memoized helper method.
* The one-liner `is_expected` syntax also works with block expectations.
* `subject`, `before`, `after` and `let` definitions must come before examples.
* Runs much faster.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.