### PR TITLE
Add m2cgen for transpiling ML models into Ruby code

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 * [AI4R](https://github.com/sergiofierens/ai4r) - Algorithms covering several Artificial intelligence fields.
 * [Awesome Machine Learning with Ruby](https://github.com/arbox/machine-learning-with-ruby) - A Curated List of Ruby Machine Learning Links and Resources.
+* [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool to transpile trained classic ML models into a native Ruby code with zero dependencies.
 * [PredictionIO Ruby SDK](https://github.com/PredictionIO/PredictionIO-Ruby-SDK) - The PredictionIO Ruby SDK provides a convenient API to quickly record your users' behavior and retrieve personalized predictions for them.
 * [rb-libsvm](https://github.com/febeling/rb-libsvm) - Ruby language bindings for LIBSVM. SVM is a machine learning and classification algorithm.
 * [ruby-fann](https://github.com/tangledpath/ruby-fann) - Ruby library for interfacing with FANN (Fast Artificial Neural Network).


### PR DESCRIPTION
## m2cgen

[GitHub repo](https://github.com/BayesWitnesses/m2cgen).

## What is this Ruby project?

`m2cgen` is a lightweight library with command line interface which allows to transpile trained machine learning models into a native code of Ruby programming language. Examples of generated Ruby code can be found [here](https://github.com/BayesWitnesses/m2cgen/tree/master/generated_code_examples/ruby).

## What are the main difference between this Ruby project and similar ones?

In comparison with [`sklearn-porter`](https://github.com/nok/sklearn-porter), `m2cgen` supports much more machine learning models to transpile and is actively maintained.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.