### PR TITLE
Add active_snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,6 +879,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 ## ORM/ODM Extensions
 
 * Auditing and Versioning
+  * [active_snapshot](https://github.com/westonganger/active_snapshot) - Simplified snapshots and restoration for ActiveRecord models and associations with a transparent white-box implementation 
   * [acts_as_archival](https://github.com/expectedbehavior/acts_as_archival) - ActiveRecord plugin for atomic object tree archiving.
   * [ActsAsParanoid](https://github.com/ActsAsParanoid/acts_as_paranoid) - ActiveRecord plugin allowing you to hide and restore records without actually deleting them.
   * [Audited](https://github.com/collectiveidea/audited) - Audited is an ORM extension for ActiveRecord & MongoMapper that logs all changes to your models.


### PR DESCRIPTION
## Project

https://github.com/westonganger/active_snapshot
https://rubygems.org/gems/active_snapshot

## What is this Ruby project?

From the Readme

> Simplified snapshots and restoration for ActiveRecord models and associations with a transparent white-box implementation.
> 
> Key Features:
> 
>     Create and Restore snapshots of a parent record and any specified child records
>     Predictible and explicit behaviour provides much needed clarity to your restore logic
>     Snapshots are created upon request only, we do not use any callbacks
>     Tiny method footprint so its easy to completely override the logic later
> 
> Why This Library:
> 
> Model Versioning and Restoration require concious thought, design, and understanding. You should understand your versioning and restoration process completely. This gem's small API and fully understandable design fully supports this.
> 
> I do not recommend using paper_trail-association_tracking because it is mostly a blackbox solution which encourages you to set it up and then assume its Just WorkingTM. This makes for major data problems later. Dont fall into this trap. Instead read this gems brief source code completely before use OR copy the code straight into your codebase. Once you know it, then you are free.

## What are the main difference between this Ruby project and similar ones?

I extracted and maintain the popular gem [`paper_trail-association_tracking`](https://github.com/westonganger/paper_trail-association_tracking) which is the most similar gem. I have created this gem active_snapshot as a more comprehensible white-box solution. I have been seeing consistent growing interest in this library since I released it.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.