### PR TITLE
Add Remote Record to Abstractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Light Service](https://github.com/adomokos/light-service) - Series of Actions with an emphasis on simplicity.
 * [Mutations](https://github.com/cypriss/mutations) - Compose your business logic into commands that sanitize and validate input.
 * [Rails Event Store (RES)](https://github.com/RailsEventStore/rails_event_store) - A library for publishing, consuming, storing and retrieving events. It's your best companion for going with an event-driven architecture for your Rails application.
+* [Remote Record](https://github.com/raisedevs/remote_record) - Model remote resources consistently in your app.
 * [Responders](https://github.com/heartcombo/responders) - A set of Rails responders to dry up your application.
 * [Surrounded](https://github.com/saturnflyer/surrounded) - Encapsulated related objects in a single system to add behavior during runtime. Extensible implementation of DCI.
 * [Trailblazer](https://github.com/trailblazer/trailblazer) - Trailblazer is a thin layer on top of Rails. It gently enforces encapsulation, an intuitive code structure and gives you an object-oriented architecture.


### PR DESCRIPTION
## Project

[Remote Record](https://github.com/raisedevs/remote_record/)

[RubyGems](https://rubygems.org/gems/remote_record)

[Blog post](https://raise.dev/blog/remote-record)

## What is this Ruby project?

Dealing with remote resources (objects stored on other services) is inconsistent. Perhaps you wrap things in service objects. Perhaps you have domain models. Perhaps you're working with an API client directly. Remote Record lets you bring those things in line and talk to external APIs with a consistent interface.

If you have a record that's directly linked to a remote resource, all you need to do is tell Remote Record where it can find the ID and tell it how to fetch the record. For example, let's say you're storing tracks on Spotify using Remote Record. You'd write a remote record class, which inherits from `RemoteRecord::Base`. When you call `remote` on an Active Record model instance, you'll get an instance of this class.

```ruby
# app/lib/remote_record/spotify/track.rb
module RemoteRecord
  module Spotify
    class Track < RemoteRecord::Base
      def get
        client(authorization).get("tracks/#{remote_resource_id}").body
      end
  
      private
    
      def client(token)
        @client = Faraday.new('https://api.spotify.com/v1/') do |conn|
          conn.request :json
          conn.response :json
          conn.use Faraday::Response::RaiseError
          conn.headers['Authorization'] = "Bearer #{token}"
        end
      end
    end
  end
end
```

Now, to use this remote record class in a model, you could do the following:

```ruby
# app/models/spotify/track_reference.rb
class Spotify::TrackReference < ApplicationRecord
  belongs_to :user
  include RemoteRecord
  remote_record do |config|
    config.authorization { |record| record.user.spotify_token }
  end
end
```

Now if you call `remote` on a `Spotify::TrackReference`, Remote Record will use the `remote_resource_id` on the record to fetch the track details from Spotify, using the token of the user that it belongs to.

## What are the main difference between this Ruby project and similar ones?

Remote Record echoes similar attempts such as Rails' own [Active Resource](https://github.com/rails/activeresource) and [Her](https://github.com/remi/her). Those two libraries make a lot of assumptions about the schema of an API. Remote Record, however, doesn't assume anything about record IDs or the schema of the remote service.

Remote Record has been running in production at raise.dev since it was initially created. It'll continue to receive updates and mature under us, but we're also very open to contributions and even have some good first-timer issues open for Hacktoberfest.
---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.