### PR TITLE
Add Avo to [Admin interfaces]

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [ActiveAdmin](http://activeadmin.info) - A Ruby on Rails framework for creating elegant backends for website administration.
 * [ActiveScaffold](https://github.com/activescaffold/active_scaffold) - ActiveScaffold provides quick and powerful user interfaces for CRUD (create, read, update, delete) operations for Rails applications. It's excellent for generating admin interfaces, managing Data-Heavy Applications, creating Widgets or for quick prototyping. ActiveScaffold is completly customizable and offers a bunch of additional features including searching, pagination, layout control and overrides of fields, forms and templates.
 * [Administrate](https://github.com/thoughtbot/administrate) - A Rails engine that helps you put together a super-flexible admin dashboard, by Thoughtbot.
+* [Avo](https://avohq.io) - Avo is a next-generation framework that empowers developers and teams to create fantastic admin panels for Ruby on Rails projects in hours, not days or weeks. Fast, extendable, with a developer-friendly API, it just works out of the box.
 * [bhf](http://antpaw.github.io/bhf/) - A simple to use Rails-Engine-Gem that offers an admin interface for trusted user.
 * [MotorAdmin](https://github.com/motor-admin/motor-admin-rails) - A low-code Admin panel and Business Intelligence Rails engine. No DSL - configurable from the UI.
 * [RailsAdmin](https://github.com/sferik/rails_admin) - A Rails engine that provides an easy-to-use interface for managing your data.


### PR DESCRIPTION
## Project

Avo Admin for Rails

https://avohq.io
https://github.com/avo-hq/avo

## What is this Ruby project?

It's simply the best way to build a Ruby on Rails admin
Avo is a next-generation framework that empowers developers and teams to create fantastic admin panels for Ruby on Rails projects in hours, not days or weeks.
Fast, extendable, with a developer-friendly API, it just works out of the box.


## What are the main difference between this Ruby project and similar ones?

It looks and works beautifully out of the box. It has a DSL that rails developers know. It abstracts away the asset pipeline. When you need more then CRUD, you can escape and write regular Rails code.

Thank you,
Adrian


---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.