### PR TITLE
Niceql

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 
 ## Code Formatting
 
+* [niceql](https://github.com/alekseyl/niceql) - A dependentless SQL and SQL errors formatting and colorizing. ActiveRecord seemless integration.   
 * [prettier](https://github.com/prettier/plugin-ruby) - A prettier plugin for the Ruby language.
 * [RuboCop](https://github.com/rubocop-hq/rubocop) - A static code analyzer, based on the community Ruby style guide.
   * [Rubocop Rails](https://github.com/rubocop-hq/rubocop-rails) - A RuboCop extension focused on enforcing Rails best practices and coding conventions.


### PR DESCRIPTION
## Project
[Niceql-repo](https://github.com/alekseyl/niceql)

Niceql is a small, nice, simple and no-dependency solution for SQL prettifying for Ruby. 
It can be used in an irb console without any dependencies ( run bin/console and look for examples ).

## What is this Ruby project?

Raw SQL and SQL-errors prettifier. 

Rem. SQL-errors prettifying only works with PostgreSQL 

## Before/After 
### SQL prettifier: 
![alt text](https://github.com/alekseyl/niceql/raw/master/to_niceql.png "To_niceql")

### PG errors prettifier 

before: 
![alt text](https://github.com/alekseyl/niceql/raw/master/err_was.png "To_niceql")

after:
![alt text](https://github.com/alekseyl/niceql/raw/master/err_now.png "To_niceql")


## What are the main difference between this Ruby project and similar ones?

I know only one similar project anbt-sql-formatter (https://github.com/sonota88/anbt-sql-formatter). 

Non-human readble formatting without colors: 
 
$ echo "select a,b from c;" | anbt-sql-formatter
SELECT
        a
        , b
    FROM
        c
;
$
---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.