### PR TITLE
Add Kanrisuru

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Chef](https://github.com/chef/chef) - A systems integration framework, built to bring the benefits of configuration management to your entire infrastructure.
 * [Einhorn](https://github.com/stripe/einhorn) - Einhorn will open one or more shared sockets and run multiple copies of your process. You can seamlessly reload your code, dynamically reconfigure Einhorn, and more.
 * [Itamae](https://github.com/itamae-kitchen/itamae) - Simple and lightweight configuration management tool inspired by Chef.
+* [Kanrisuru](https://github.com/avamia/kanrisuru) - Manage remote infrastructure in Ruby
 * [Lita](https://www.lita.io/) - ChatOps for Ruby: A pluggable chat bot framework usable with any chat service.
 * [Logstash](https://github.com/elastic/logstash) - Logs/event transport, processing, management, search.
 * [Mina](https://github.com/mina-deploy/mina) - Really fast deployer and server automation tool.


### PR DESCRIPTION
## Kanrisuru
- [repo](https://github.com/avamia/kanrisuru)
- [website](https://kanrisuru.com/)

## What is Kanrisuru?
Kanrisuru manages remote infrastructure with plain ruby objects. The goal with Kanrisuru is to provide a clean objected oriented wrapper over the most commonly used linux commands, with a simple command interface; and with any usable output, present the text stream as parsed, structured data. Kanrisuru doesn't use remote agents to run commands on hosts, nor does the project rely on a large complex set of dependencies.

## What are the main difference between this Ruby project and similar ones?
Kanrisuru aims to fill a gap in what's available for developers and devops engineers to manage remote infrastructure. There's several well known solutions available, but are large, complex and bloated. Other issues arise with being tied to running through a configuration file, which has its place, but to dynamically make changes to a server or monitor infrastructure, this can be tricky to pull off with the existing systems.

With some of the smaller sized infra management projects available, while they are lightweight, they tend to leave it to the developer to parse results from the remote server.

Kanrisuru fills this gap by porting the commonly used linux commands into a robust, but also lightweight set of ruby methods. This includes handling option preparation to execute the command. And with any output data from the remote server, Kanrisuru parses this into structured data, making it much easier for the developer to write actionable code based on what happened.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.