### PR TITLE
Adding rodauth-oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * OAuth:
   * [Doorkeeper](https://github.com/doorkeeper-gem/doorkeeper) - An OAuth2 provider for Rails.
   * [OAuth2](https://github.com/intridea/oauth2) - A Ruby wrapper for the OAuth 2.0 protocol.
+  * [Rodauth-Oauth](https://gitlab.com/honeyryderchuck/rodauth-oauth) - A rodauth OAuth and OpenID provider plugin.
 
 ## Authorization
 


### PR DESCRIPTION
## Project

* https://gitlab.com/honeyryderchuck/rodauth-oauth
* https://honeyryderchuck.gitlab.io/rodauth-oauth
* https://honeyryderchuck.gitlab.io/httpx/2021/03/15/oidc-provider-on-rails-using-rodauth-oauth.html

## What is this Ruby project?

rodauth-oauth is a plugin for rodauth for building OAuth and OpenID providers.

## What are the main difference between this Ruby project and similar ones?

* being built on top of rodauth, it's ideal for non-rails apps (but can be used in rails via `rodauth-rails`)
* lower footprint, easy setup, faster bootstrap (read the linked blog post), focus on security
* lots of advanced features (read the [wiki](https://honeyryderchuck.gitlab.io/rodauth-oauth/wiki/Home.html))
* ships both Oauth 2.0 and OpenID, making sure both layers work together
* supports SAML assertion tokens and MAC auth scheme
* [why you should use rodauth-oauth instead of doorkeeper](https://honeyryderchuck.gitlab.io/rodauth-oauth/wiki/FAQ) section.
