### PR TITLE
added human friendly time formatting gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [validates_timeliness](https://github.com/adzap/validates_timeliness) - Date and time validation plugin for ActiveModel and Rails.
 * [working_hours](https://github.com/intrepidd/working_hours) - A modern ruby gem allowing to do time calculation with working hours.
 * [yymmdd](https://github.com/sshaw/yymmdd) - Tiny DSL for idiomatic date parsing and formatting.
+* [stamp](https://github.com/jeremyw/stamp) - Format dates and times based on human-friendly examples, not arcane strftime directives.
 
 ## Debugging Tools
 


### PR DESCRIPTION
## Project

### Project name: stamp
### Project type:  Ruby gem


* [Github](https://github.com/jeremyw/stamp)
* [Rubygems](https://rubygems.org/gems/stamp)
* [Documentation](https://www.rubydoc.info/gems/stamp/0.6.0)

## What is this Ruby project?

`stamp` is a Ruby gem that helps you format dates and times based on human-friendly examples, not arcane strftime directives.

## What are the main difference between this Ruby project and similar ones?

### Features
 * Abbreviated and full names of months and weekdays are recognized.
 * Days with or without a leading zero work instinctively.
 * Standard time zone abbreviations are recognized; e.g. "UTC", "PST", "EST".
 * Include any extraneous text you'd like; e.g. "DOB:".

Give Date#stamp an example date string with whatever month, day, year, and weekday parts you'd like, and your date will be formatted accordingly:

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.