### PR TITLE
add Cloud 66 to Devops tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Capistrano](http://capistranorb.com) - A remote server automation and deployment tool written in Ruby.
 * [Centurion](https://github.com/newrelic/centurion) - A mass deployment tool for Docker fleets.
 * [Chef](https://github.com/chef/chef) - A systems integration framework, built to bring the benefits of configuration management to your entire infrastructure.
+* [Cloud 66](https://www.cloud66.com/) - Deploy your code directly from your repo to any cloud or server.
 * [Einhorn](https://github.com/stripe/einhorn) - Einhorn will open one or more shared sockets and run multiple copies of your process. You can seamlessly reload your code, dynamically reconfigure Einhorn, and more.
 * [Itamae](https://github.com/itamae-kitchen/itamae) - Simple and lightweight configuration management tool inspired by Chef.
 * [Lita](https://www.lita.io/) - ChatOps for Ruby: A pluggable chat bot framework usable with any chat service.


### PR DESCRIPTION
Added Cloud 66 to the DevOps tools.

**Thanks for contributing to Awesome Ruby! Please take a look at the [contribution guidelines and quality standard](https://github.com/markets/awesome-ruby/blob/master/CONTRIBUTING.md) first and :scissors: remove this line.**

## Project

Title and urls (GitHub, RubyGems, project page, blog posts, ...).

## What is this Ruby project?

Describe features.

## What are the main difference between this Ruby project and similar ones?

Enumerate comparisons.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.