### PR TITLE
Add Standard Code Formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
   * [Rubocop Rails](https://github.com/rubocop-hq/rubocop-rails) - A RuboCop extension focused on enforcing Rails best practices and coding conventions.
   * [Rubocop Rspec](https://github.com/rubocop-hq/rubocop-rspec) - Code style checking for RSpec files
   * [Rubocop Performance](https://github.com/rubocop-hq/rubocop-performance) - A RuboCop extension focused on code performance checks.
+* [Standard](https://github.com/testdouble/standard) - Ruby Style Guide, with linter & automatic code fixer
 
 ## Code Highlighting
 


### PR DESCRIPTION
## Project

- [Standard](https://github.com/testdouble/standard)


## What is this Ruby project?

Standard is a code formatter based on Rubocop, and it comes with its own predfined styleguide, linter, and fixer. It's great for those who want an opinionated formatter and don't really want to define their own rules.

## What are the main difference between this Ruby project and similar ones?

Enumerate comparisons.
- No configuration.
- Automatically format code.
- Catch style issues & programmer errors early

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.