### PR TITLE
Update name of dry-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 * [Bitwise](https://github.com/kenn/bitwise) - Fast, memory efficient bitwise operations on large binary strings
 * [Finishing Moves](https://github.com/forgecrafted/finishing_moves) - Small, focused, incredibly useful methods added to core Ruby classes. Includes the endlessly useful `nil_chain`.
 * [Docile](https://github.com/ms-ati/docile) - A tiny library that lets you map a DSL (domain specific language) to your Ruby objects in a snap.
-* [dry-rb](https://github.com/dry-rb) - rb is a collection of next-generation Ruby libraries, each intended to encapsulate a common task.
+* [dry-rb](https://github.com/dry-rb) - dry-rb is a collection of next-generation Ruby libraries, each intended to encapsulate a common task.
 * [Hamster](https://github.com/hamstergem/hamster) - Efficient, immutable, and thread-safe collection classes for Ruby.
 * [Hanami::Utils](https://github.com/hanami/utils) - Lightweight, non-monkey-patch class utilities for Hanami and Ruby app.
 * [Ruby Facets](https://github.com/rubyworks/facets) - The premiere collection of general purpose method extensions and standard additions for Ruby.


### PR DESCRIPTION
The library formerly known as `hanami-cli` is now known as `dry-cli`: https://github.com/dry-rb/dry-cli/pull/57

(There is new library with the name `hanami-cli` but it's the CLI for Hanami, not a general purpose CLI framework)