### PR TITLE
Add whatsapp ruby gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1323,6 +1323,7 @@ Online tools, services and APIs to simplify development.
 * [tweetstream](https://github.com/tweetstream/tweetstream) - A simple library for consuming Twitter's Streaming API.
 * [twilio-ruby](https://github.com/twilio/twilio-ruby) - A module for using the Twilio REST API and generating valid TwiML.
 * [twitter](https://github.com/sferik/twitter) - A Ruby interface to the Twitter API.
+* [whatsapp-sdk](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk) - Ruby client for the Whatsapp API.
 * [wikipedia](https://github.com/kenpratt/wikipedia-client) - Ruby client for the Wikipedia API.
 * [Yt](https://github.com/Fullscreen/yt) - An object-oriented Ruby client for YouTube API V3.
 


### PR DESCRIPTION
## Project

Whatsapp SDK:
Github: https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk
RubyGem: https://rubygems.org/gems/whatsapp_sdk
Project Page: https://ignacio-chiazzo.github.io/ruby_whatsapp_sdk

## What is this Ruby project?

Use the Ruby Whatsapp SDK to communicate with Whatsapp API using the Cloud API. Create bots to send and receive messages using the Whatsapp SDK in a few minutes.

## What are the main differences between this Ruby project and similar ones?

Enumerate comparisons.

- I didn't find any library that have all the features I needed so I created one. 

List of features:
- Medias API - Manage Medias.
- Messages API - Manage any type of message (text, audio, document, button etc). It also allows sending links etc.
- The gem can use either JSON or objects to talk to the API. This is useful when working with multiple integrations.
- Phone Numbers API - Manage Phone Numbers.
