### PR TITLE
Add Firezone to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -1140,6 +1140,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [BeEF](http://beefproject.com) - BeEF is short for The Browser Exploitation Framework. It is a penetration testing tool that focuses on the web browser.
 * [bundler-audit](https://github.com/rubysec/bundler-audit) - Patch-level security verification for Bundler.
 * [Fingerprinter](https://github.com/erwanlr/Fingerprinter) - CMS/LMS/Library etc versions fingerprinter.
+* [Firezone](https://github.com/firezone/firezone) - Self-hosted VPN server using WireGuard.
 * [haiti](https://github.com/noraj/haiti) - Hash type identifier (CLI & lib).
 * [Metasploit](https://github.com/rapid7/metasploit-framework) - World's most used penetration testing software.
 * [Pipal](https://github.com/digininja/pipal) - Password analyser and statistics generator


### PR DESCRIPTION
## Project

Firezone
Built mostly with Ruby + Elixir (https://github.com/firezone/firezone).

## What is this Ruby project?

A self-hosted VPN server and Linux firewall. It's used to manage remote access to your private networks or as a VPN to encrypt your online traffic.

Some features include:
* Fast: Uses WireGuard® to be [3-4 times](https://wireguard.com/performance/) faster than OpenVPN.
* SSO Integration: Authenticate using any identity provider with an OpenID Connect (OIDC) connector.
* No dependencies: All dependencies are bundled thanks to [Chef Omnibus](https://github.com/chef/omnibus).
* Simple: Takes minutes to set up. Manage via a simple CLI.
* Secure: Runs unprivileged. HTTPS enforced. Encrypted cookies.
* Firewall included: Uses Linux [nftables](https://netfilter.org/) to block unwanted egress traffic.

## What are the main difference between this Ruby project and similar ones?

I did not find any similar projects.
