### PR TITLE
Technical/Add SmtpMock to Testing section, Mock subsection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1256,6 +1256,7 @@ Online tools, services and APIs to simplify development.
   * [ActiveMocker](https://github.com/zeisler/active_mocker) - Generate mocks from ActiveRecord models for unit tests that run fast because they don’t need to load Rails or a database.
   * [DnsMock](https://github.com/mocktools/ruby-dns-mock) - Ruby DNS mock. Mimic any DNS records for your test environment and even more.
   * [DuckRails](https://github.com/iridakos/duckrails) - Tool for mocking API endpoints quickly & dynamically.
+  * [SmtpMock](https://github.com/mocktools/ruby-smtp-mock) - Ruby SMTP mock. Mimic any SMTP server behaviour for your test environment with fake SMTP server.
   * [TestXml](https://github.com/alovak/test_xml) - TestXml is a small extension for testing XML/HTML.
   * [WebMock](https://github.com/bblimke/webmock) - Library for stubbing and setting expectations on HTTP requests.
 * WebDrivers


### PR DESCRIPTION
## Project

💎 Ruby SMTP mock. Mimic any SMTP server behaviour for your test environment with fake SMTP server. 

**GitHub:** https://github.com/mocktools/ruby-smtp-mock
**RubyGems:** https://rubygems.org/gems/smtp_mock
**RubyWeekly:** https://rubyweekly.com/issues/623

## What is this Ruby project?

1. Ability to handle configurable behaviour and life cycles of SMTP mock server(s)
2. Dynamic/manual port assignment
3. Test framework agnostic (it's PORO, so you can use it outside of `RSpec`, `Test::Unit` or `MiniTest`)
4. Simple and intuitive DSL
5. RSpec integration out of the box
6. Includes easy system dependency manager

## What are the main difference between this Ruby project and similar ones?

The first flexible SMTP mocking tool for Ruby 💎

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.