### PR TITLE
add Svix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1304,6 +1304,7 @@ Online tools, services and APIs to simplify development.
 * [Slack Notifier](https://github.com/stevenosloan/slack-notifier) - A simple wrapper for posting to Slack channels.
 * [Slack ruby gem](https://github.com/aki017/slack-ruby-gem) - A Ruby wrapper for the Slack API.
 * [soundcloud-ruby](https://github.com/soundcloud/soundcloud-ruby) - Official SoundCloud API Wrapper for Ruby.
+* [svix](https://github.com/svix/svix-webhooks/tree/main/ruby) - Ruby library for sending webhooks and verifying signatures.
 * [t](https://github.com/sferik/t) - A command-line power tool for Twitter.
 * [terjira](https://github.com/keepcosmos/terjira) - A command-line power tool for Jira.
 * [tweetstream](https://github.com/tweetstream/tweetstream) - A simple library for consuming Twitter's Streaming API.


### PR DESCRIPTION
## Project

Svix
https://github.com/svix/svix-webhooks/tree/main/ruby
https://www.svix.com/
https://rubygems.org/gems/svix

## What is this Ruby project?

This is the ruby library for using the Svix API. Svix is a webhooks as a service provider that makes it super simple to launch a scalable webhook feature in days, not months.

## What are the main difference between this Ruby project and similar ones?

Makes it super easy to build a webhook service on par with the likes of Stripe and Brex. Easy to implement features like automatic retries, exponential backoff, and signature verification.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.