### PR TITLE
[html-xml-parsing] Add Nokolexbor

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,6 +739,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [HappyMapper](https://github.com/dam5s/happymapper) - Object to XML mapping library, using Nokogiri.
 * [HTML::Pipeline](https://github.com/jch/html-pipeline) - HTML processing filters and utilities.
 * [Nokogiri](https://nokogiri.org) - An HTML, XML, SAX, and Reader parser with XPath and CSS selector support.
+* [Nokolexbor](https://github.com/serpapi/nokolexbor) - High-performance HTML5 parser based on Lexbor, with support for both CSS selectors and XPath.
 * [Oga](https://gitlab.com/yorickpeterse/oga) - An XML/HTML parser written in Ruby. Oga does not require system libraries such as libxml, making it easier and faster to install on various platforms.
 * [Ox](https://github.com/ohler55/ox) - A fast XML parser and Object marshaller.
 * [ROXML](https://github.com/Empact/roxml) - Custom mapping and bidirectional marshalling between Ruby and XML using annotation-style class methods, via Nokogiri or LibXML.


### PR DESCRIPTION
## Project

Nokolexbor

Github: https://github.com/serpapi/nokolexbor
Rubygem: https://rubygems.org/gems/nokolexbor (13k+ downloads for now, 3 months old)

## What is this Ruby project?

High-performance HTML5 parser based on [Lexbor](https://github.com/lexbor/lexbor) (C engine), with support for both CSS selectors and XPath.

## What are the main difference between this Ruby project and similar ones?

- Meant to be a drop-in replacement for [Nokogiri](https://nokogiri.org/).
- [5.2x faster at parsing HTML and up to 997x faster at CSS selectors than Nokogiri](https://github.com/serpapi/nokolexbor#benchmarks).

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.