### PR TITLE
[testing] add turbo tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1276,6 +1276,7 @@ Online tools, services and APIs to simplify development.
   * [Knapsack](https://github.com/ArturT/knapsack) - Optimal test suite parallelisation across CI nodes for RSpec, Cucumber, Minitest, Spinach and Turnip.
   * [mutant](https://github.com/mbj/mutant) - Mutant is a mutation testing tool for Ruby.
   * [Parallel Tests](https://github.com/grosser/parallel_tests) - Speedup Test::Unit + RSpec + Cucumber by running parallel on multiple CPUs (or cores).
+  * [Turbo Tests](https://github.com/serpapi/turbo_tests) - Run RSpec tests on multiple cores. Like `parallel_tests` but with incremental summarized output.
   * [power_assert](https://github.com/k-tsj/power_assert) - Power Assert for Ruby.
   * [Ruby-JMeter](https://github.com/flood-io/ruby-jmeter) - A Ruby based DSL for building JMeter test plans.
   * [Spring](https://github.com/rails/spring) - Preloads your rails environment in the background for faster testing and Rake tasks.


### PR DESCRIPTION
## Project

Turbo tests

GitHub: https://github.com/serpapi/turbo_tests
RubyGem: https://rubygems.org/gems/turbo_tests (175k+ downloads)

## What is this Ruby project?

Run RSpec tests on multiple cores with incremental summarized output.

## What are the main difference between this Ruby project and similar ones?

- drop-in replacement for [`grosser/parallel_tests`](https://github.com/grosser/parallel_tests). 
- [`parallel_tests` is great, but it messes output, `turbo_tests` output looks like regular `rspec`](https://github.com/serpapi/turbo_tests#why-incremental-output).
- RSpec tests on multiple cores with incremental summarized output

📌Note: This gem will not be useful **if** [`parallel_tests` author implement incremental summarized output](https://github.com/grosser/parallel_tests/issues/708) (3 years later no updates), or **if** [RSpec implements built-in parallel testing](https://github.com/rspec/rspec-rails/issues/2104#issuecomment-658474900) (2 years seems to be no updates).

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.