### PR TITLE
Add Lamby to serverless section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1077,6 +1077,7 @@ Where to discover new Ruby libraries, projects and trends.
 
 * [FaaStRuby](https://faastruby.io) - Serverless Software Development Platform for Ruby and Crystal developers.
 * [Jets](https://github.com/tongueroo/jets) - A Ruby Serverless Framework to create and deploy serverless microservices with ease, and to seamlessly glue AWS services.
+* [🐑 Lamby](https://lamby.custominktech.com/) - Simple Rails & AWS Lambda Integration using Rack
 
 ## Scheduling
 


### PR DESCRIPTION
I was shocked to see this wasn't already on this list.

## Project

### 🐑 [Lamby](https://lamby.custominktech.com/)

## What is this Ruby project?

 - Simple Rails & AWS Lambda Integration using Rack

## What are the main difference between this Ruby project and similar ones?

 - It's a great DX since it's "just a Rails app" in a single lambda.
 - It brings a lot of traditional thinking into a "serverless" realm
 - There are other gems in the lamby ecosystem like [Lambdakiq](https://github.com/customink/lambdakiq) for a sidekiq-like approach to using SQS

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.