### PR TITLE
Add ElasticsearchRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -1128,6 +1128,7 @@ Where to discover new Ruby libraries, projects and trends.
 
 * [chewy](https://github.com/toptal/chewy) - High-level Elasticsearch Ruby framework based on the official elasticsearch-ruby client.
 * [elasticsearch-ruby](https://github.com/elastic/elasticsearch-ruby) - Ruby integrations for Elasticsearch.
+* [ElasticsearchRecord](https://github.com/ruby-smart/elasticsearch_record) - Full ActiveRecord adapter for elasticsearch
 * [elastics](https://github.com/printercu/elastics-rb) - Simple ElasticSearch client with support for migrations and ActiveRecord integration.
 * [has_scope](https://github.com/heartcombo/has_scope) - Has scope allows you to easily create controller filters based on your resources named scopes.
 * [Mongoid Search](https://github.com/mauriciozaffari/mongoid_search) - Simple full text search implementation for Mongoid.


### PR DESCRIPTION
## ElasticsearchRecord

ActiveRecord adapter for Elasticsearch

[GitHub](https://github.com/ruby-smart/elasticsearch_record)

[Rubygems](https://rubygems.org/gems/elasticsearch_record)

## What is this Ruby project?

ElasticsearchRecord is a ActiveRecord adapter and provides similar functionality for Elasticsearch.

## What are the main difference between this Ruby project and similar ones?

- Full integration of the **ActiveRecord model** _(same methods, same behaviours)_
- Modified integration of **Active Record Query Interface** _(extended with 'filter, must, must_not, should, aggregations')_
- Schema-dumping & migrations
- Instrumentation

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.