### PR TITLE
Remove archived repository Piggybak

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,6 @@ Where to discover new Ruby libraries, projects and trends.
 * [Conekta](https://github.com/conekta/conekta-ruby) - Conekta Ruby bindings.
 * [credit_card_validations](https://github.com/didww/credit_card_validations) - A ruby gem for validating credit card numbers, generating valid numbers, Luhn checks.
 * [Paypal Merchant SDK](https://github.com/paypal/merchant-sdk-ruby) - Official Paypal Merchant SDK for Ruby.
-* [Piggybak](https://github.com/piggybak/piggybak) - Modular, Extensible open-source ecommerce solution for Ruby on Rails.
 * [ROR Ecommerce](https://github.com/drhenner/ror_ecommerce) - A Rails e-commerce platform.
 * [Solidus](https://github.com/solidusio/solidus) - An open source, eCommerce application for high volume retailers.
 * [Spree](https://github.com/spree/spree) - Spree is a complete open source e-commerce solution for Ruby on Rails.


### PR DESCRIPTION
Piggybak repository is now archived:
>This repository has been archived by the owner on Jul 16, 2020. It is now read-only.


Blog post about sunsetting the gem:
https://www.endpointdev.com/blog/2018/02/sunsetting-piggybak/