### PR TITLE
Add Grim

### DIFF
--- a/README.md
+++ b/README.md
@@ -981,6 +981,7 @@ Where to discover new Ruby libraries, projects and trends.
 ## PDF
 
 * [CombinePDF](https://github.com/boazsegev/combine_pdf) - A Pure ruby library to merge or stump PDF files, number pages and more.
+* [Grim](https://github.com/jonmagic/grim) - Extract PDF pages as images and text. A simple Ruby API to ghostscript, imagemagick, and pdftotext.
 * [HexaPDF](https://github.com/gettalong/hexapdf) - A Versatile PDF Creation and Manipulation Library For Ruby.
 * [InvoicePrinter](https://github.com/strzibny/invoice_printer) - Super simple PDF invoicing in Ruby (built on top of Prawn).
 * [Kitabu](https://github.com/fnando/kitabu) - A framework for creating e-books from Markdown/Textile text markup using Ruby.


### PR DESCRIPTION
## Project

**Grim** - Extract PDF pages as images and text. A simple Ruby API to ghostscript, imagemagick, and pdftotext.

- https://github.com/jonmagic/grim
- https://rubygems.org/gems/grim
- http://theprogrammingbutler.com/blog/archives/2011/09/06/grim/
- http://theprogrammingbutler.com/blog/archives/2011/10/06/grim-multiprocessor-to-the-rescue/

## What is this Ruby project?

This is a simple Ruby API to powerful tools like Ghostscript, imagemagick, and pdftotext. It supports multiple image processors with fallback.

## What are the main difference between this Ruby project and similar ones?

This library is focused purely on extracting pdf pages and text. It was built to power https://speakerdeck.com.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.