### PR TITLE
Add Artoo Arduino

### DIFF
--- a/README.md
+++ b/README.md
@@ -1066,6 +1066,7 @@ Where to discover new Ruby libraries, projects and trends.
 
 * [Arli](https://github.com/kigster/arli) - Arli is the CLI tool for searching, installing, and packaging Arduino libraries with a project using a YAML-based Arlifile. It's a "Bundler for Arduino Development".
 * [Artoo](http://artoo.io) - Next generation robotics framework with support for different platforms: Arduino, Leap Motion, Pebble, Raspberry Pi, etc.
+* [Artoo Arduino](https://github.com/josephschito/artoo-arduino) - Simple Ruby Arduino library (updated to work with Ruby >=3)
 
 ## RSS
 


### PR DESCRIPTION
## Project
Artoo Arduino, https://github.com/josephschito/artoo-arduino, updated to work with Ruby >=3 versions

## What is this Ruby project?
[Description](https://github.com/josephschito/artoo-arduino#artoo-adaptor-for-arduino)

## What are the main difference between this Ruby project and similar ones?
It's updated and working.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.