### PR TITLE
Add `online_migrations` gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Foreigner](https://github.com/matthuhiggins/foreigner) - Adds foreign key helpers to migrations and correctly dumps foreign keys to schema.rb.
 * [Large Hadron Migrator](https://github.com/soundcloud/lhm) - Online MySQL schema migrations without locking the table.
 * [Lol DBA](https://github.com/plentz/lol_dba) - Scan your models and displays a list of columns that probably should be indexed.
+* [Online Migrations](https://github.com/fatkodima/online_migrations) - Catch unsafe PostgreSQL migrations in development and run them easier in production.
 * [Polo](https://github.com/IFTTT/polo) - Creates sample database snapshots to work with real world data in development.
 * [PgHero](https://github.com/ankane/pghero) - Postgres insights made easy.
 * [Rails DB](https://github.com/igorkasyanchuk/rails_db) - Database Viewer and SQL Query Runner.


### PR DESCRIPTION
## Project

* GitHub: https://github.com/fatkodima/online_migrations
* RubyGems: https://rubygems.org/gems/online_migrations

## What is this Ruby project?

An established gem to run PostgreSQL migrations safely and easily. It has code helpers for table/column renaming, changing column type, adding columns with default, background migrations, etc. Additionally it a has a powerful framework to run large data changes via background migrations.

## What are the main difference between this Ruby project and similar ones?

It is an alternative to [`strong_migrations`](https://github.com/ankane/strong_migrations). There is a [comparison](https://github.com/fatkodima/online_migrations#comparison-to-strong_migrations) in the project's readme.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.