### PR TITLE
Add KatakataIrb gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,6 +800,7 @@ Where to discover new Ruby libraries, projects and trends.
 ## IRB
 
 * [Clipboard](https://github.com/janlelis/clipboard) - Access to the system clipboard on Linux, MacOS and Windows.
+* [KatakataIrb](https://github.com/tompng/katakata_irb) - IRB with Kata(型 Type) completion.
 * [irbtools](https://github.com/janlelis/irbtools) - Improvements for Ruby's IRB.
 * [Looksee](https://github.com/oggy/looksee) - A tool for illustrating the ancestry and method lookup path of objects. Handy for exploring unfamiliar codebases.
 * [Pry](https://github.com/pry/pry) - A powerful alternative to the standard IRB shell for Ruby.


### PR DESCRIPTION
## Project

- https://github.com/tompng/katakata_irb
- https://rubygems.org/gems/katakata_irb

## What is this Ruby project?

KatakataIrb might provide a better autocompletion based on type analysis to irb (an irb plugin).

This gem was [introduced in RubyKaigi 2023](https://rubykaigi.org/2023/presentations/tompng.html).

## What are the main difference between this Ruby project and similar ones?

As far as I know, there are no similar projects.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.
