### PR TITLE
Replace Raven Ruby with Sentry Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,7 +646,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [Exception Notification](https://github.com/smartinez87/exception_notification) - A set of notifiers for sending notifications when errors occur in a Rack/Rails application.
 * [Honeybadger](https://www.honeybadger.io/) - Exception, uptime, and performance monitoring for Ruby.
 * [Nesty](https://github.com/skorks/nesty) - Nested exceptions for Ruby.
-* [Raven Ruby](https://github.com/getsentry/raven-ruby) - Raven is a Ruby client for Sentry.
+* [Sentry Ruby](https://github.com/getsentry/sentry-ruby) - The Ruby client for Sentry.
 * [Rollbar](https://github.com/rollbar/rollbar-gem) - Easy and powerful exception and error tracking for your applications.
 
 ## Event Sourcing


### PR DESCRIPTION
## Project

- https://github.com/getsentry/sentry-ruby
- https://rubygems.org/gems/sentry-ruby/

## What is this Ruby project?

It's the new Sentry SDK for Ruby, which replaces the old Raven Ruby library.

## What are the main difference between this Ruby project and similar ones?

- According to the latest [Ruby and Rails Community Survey](https://rails-hosting.com/2022/#which-error-tracking-tools-do-you-use-in-production), Sentry is the most popular option for error monitoring. So I think it's worth being included in the section.
- The old Raven Ruby has been deprecated for 3 years, and the new `sentry-ruby` gem now has been downloaded for more than 27 million times ([link](https://rubygems.org/gems/sentry-ruby/)).

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.