### PR TITLE
Add `job-iteration` and `sidekiq-iteration`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1047,6 +1047,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [Delayed::Job](https://github.com/collectiveidea/delayed_job) - Database backed asynchronous priority queue.
 * [GoodJob](https://github.com/bensheldon/good_job) - GoodJob is a multithreaded, Postgres-based, ActiveJob backend for Ruby on Rails.
 * [Gush](https://github.com/chaps-io/gush) - A parallel runner for complex workflows using only Redis and Sidekiq.
+* [JobIteration](https://github.com/Shopify/job-iteration) - An ActiveJob extension to make long-running jobs interruptible and resumable.
 * [Karafka](https://github.com/karafka/karafka) - Framework used to simplify Apache Kafka (a distributed streaming platform) based Ruby applications development.
 * [Lowkiq](https://github.com/bia-technologies/lowkiq) - Ordered processing of background jobs for cases where Sidekiq can't help.
 * [March Hare](https://github.com/ruby-amqp/march_hare) - Idiomatic, fast and well-maintained JRuby client for RabbitMQ.
@@ -1055,6 +1056,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [RocketJob](http://rocketjob.io) - Enterprise Batch Processing System focused on performance, scalability, reliability, and visibility of every job in the system. Outgrown existing solutions? Or, start small and scale up later.
 * [Shoryuken](https://github.com/phstc/shoryuken) - A super efficient AWS SQS thread based message processor for Ruby.
 * [Sidekiq](https://sidekiq.org) - A full-featured background processing framework for Ruby. It aims to be simple to integrate with any modern Rails application and much higher performance than other existing solutions.
+* [SidekiqIteration](https://github.com/fatkodima/sidekiq-iteration) - A Sidekiq extension to make long-running jobs interruptible and resumable.
 * [Sneakers](https://github.com/jondot/sneakers) - A fast background processing framework for Ruby and RabbitMQ.
 * [Sucker Punch](https://github.com/brandonhilkert/sucker_punch) - A single process background processing library using Celluloid. Aimed to be Sidekiq's little brother.
 


### PR DESCRIPTION
## Project

JobIteration from Shopify
* https://github.com/Shopify/job-iteration
* https://rubygems.org/gems/job-iteration

SidekiqIteration
* https://github.com/fatkodima/sidekiq-iteration
* https://rubygems.org/gems/sidekiq-iteration

## What is this Ruby project?

JobIteration - an ActiveJob extension to make long-running jobs interruptible and resumable.
SidekiqIteration - is a JobIteration, but adapted to work with raw Sidekiq.

## What are the main difference between this Ruby project and similar ones?

There are no alternatives to these gems.