### PR TITLE
Add Cloud 66

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Capistrano](http://capistranorb.com) - A remote server automation and deployment tool written in Ruby.
 * [Centurion](https://github.com/newrelic/centurion) - A mass deployment tool for Docker fleets.
 * [Chef](https://github.com/chef/chef) - A systems integration framework, built to bring the benefits of configuration management to your entire infrastructure.
+* [Cloud 66](https://help.cloud66.com/) - Cloud 66 gives you everything you need to build, deploy, and grow your applications on any cloud without the headache of the “server stuff”.
 * [Einhorn](https://github.com/stripe/einhorn) - Einhorn will open one or more shared sockets and run multiple copies of your process. You can seamlessly reload your code, dynamically reconfigure Einhorn, and more.
 * [Itamae](https://github.com/itamae-kitchen/itamae) - Simple and lightweight configuration management tool inspired by Chef.
 * [Lita](https://www.lita.io/) - ChatOps for Ruby: A pluggable chat bot framework usable with any chat service.

--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Capistrano](http://capistranorb.com) - A remote server automation and deployment tool written in Ruby.
 * [Centurion](https://github.com/newrelic/centurion) - A mass deployment tool for Docker fleets.
 * [Chef](https://github.com/chef/chef) - A systems integration framework, built to bring the benefits of configuration management to your entire infrastructure.
-* [Cloud 66](https://help.cloud66.com/) - Cloud 66 gives you everything you need to build, deploy, and grow your applications on any cloud without the headache of the “server stuff”.
+* [Cloud 66](https://help.cloud66.com/) - Cloud 66 gives you everything you need to build, deploy, and manage your applications on any cloud without the headache of the “server stuff”.
 * [Einhorn](https://github.com/stripe/einhorn) - Einhorn will open one or more shared sockets and run multiple copies of your process. You can seamlessly reload your code, dynamically reconfigure Einhorn, and more.
 * [Itamae](https://github.com/itamae-kitchen/itamae) - Simple and lightweight configuration management tool inspired by Chef.
 * [Lita](https://www.lita.io/) - ChatOps for Ruby: A pluggable chat bot framework usable with any chat service.


### PR DESCRIPTION

## Project
- Website: https://www.cloud66.com/
- Help page: https://help.cloud66.com/

## What is this Ruby project?
Cloud 66 - DevOps as a service that helps to build, deploy and manage Ruby application on any cloud or server. 

## What are the main difference between this Ruby project and similar ones?
Cloud 66 provides services like a PaaS platform but on your own cloud or server.

---

Please help us to maintain this collection by using reactions (:+1:, :-1:) and comments to express your feelings.