### PR TITLE
Add `fast_count`

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,6 +895,7 @@ Where to discover new Ruby libraries, projects and trends.
 
 * [bootsnap](https://github.com/Shopify/bootsnap) - Boot large Ruby/Rails apps faster.
 * [fast_blank](https://github.com/SamSaffron/fast_blank) - Provides a C-optimized method for determining if a string is blank.
+* [fast_count](https://github.com/fatkodima/fast_count) - Quickly get a count estimation for large tables (>99% of accuracy for PostgreSQL).
 * [fast_underscore](https://github.com/kddeisz/fast_underscore) - Provides a C-optimized method for transforming a string from any capitalization into underscore-separated
 * [yajl-ruby](https://github.com/brianmario/yajl-ruby) - A streaming JSON parsing and encoding library for Ruby (C bindings to yajl).
 


### PR DESCRIPTION
## Project

https://github.com/fatkodima/fast_count
https://rubygems.org/gems/fast_count

## What is this Ruby project?

Allows to quickly get an estimated number of records in large tables. While `select count(*)` can take minutes or tens of minutes for large tables, this gem allows to get a 99% accuracy estimate for PostgreSQL within milliseconds.

Was featured twice on Ruby Weekly: [one](https://rubyweekly.com/issues/651) and [two](https://rubyweekly.com/issues/664).

**Note**: I added this gem under `Optimizations` section. But it also suits to `ORM/ODM Extensions`.