### PR TITLE
Add retest gem under File System Listener section

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,6 +704,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [Guard::LiveReload](https://github.com/guard/guard-livereload) - Automatically reload your browser when 'view' files are modified.
 * [Listen](https://github.com/guard/listen) - The Listen gem listens to file modifications and notifies you about the changes.
 * [Rerun](https://github.com/alexch/rerun) - Restarts an app when the filesystem changes. Uses growl and FSEventStream if on OS X.
+* [Retest](https://github.com/alexb52/retest) - A simple CLI to watch file changes and run their matching Ruby specs. Works on any ruby projects with no setup.
 
 ## Form Builder
 


### PR DESCRIPTION
Hi,
I'm the maintainer of Retest, a file system listener gem that supports most testing conventions by default.
I'd like to reference the project on the awesome-ruby repo.

## Project

Retest has over 95,000 downloads on Rubygems and 120 stars on GitHub. 
I've personally been using and maintaining Retest daily for the last 4 years.

* https://github.com/alexb52/retest
* https://rubygems.org/gems/retest

## What is this Ruby project?

Retest is a small command-line tool that helps you refactor code by watching a file change and running its matching spec. Designed to be dev-centric and project-independent, it can be used on the fly. No Gemfile updates, no commits to a repo, and no configuration files are required to start refactoring. Works with every Ruby project (at least that is the end goal)

## What are the main differences between this Ruby project and similar ones?

Like `Guard`, Retest is a file system listener built on top of the `Listen` gem. Both gems are meant to help you run tests after file changes. 

The main difference compared to `Guard` is that it doesn't require configuration like a Guardfile, nor does it need to be added to a Gemfile. Retest matches test files to run based on Ruby naming conventions encountered in most Ruby projects and supports RSpec and Minitest out of the box. Retest aims to provide a consistent experience regardless of the Ruby project you're working on.

---

Please help us to maintain this collection by using reactions (👍, 👎) and comments to express your feelings.
