### PR TITLE
Add `AnnotateRb` gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ Where to discover new Ruby libraries, projects and trends.
 ## Documentation
 
 * [Annotate](https://github.com/ctran/annotate_models) - Add a comment documenting the current schema to the top or bottom of each of your ActiveRecord models.
+* [AnnotateRb](https://github.com/drwl/annotaterb) - Adds database schema annotations for your ActiveRecord models as text comments as well as routes. An active and maintained hard fork of Annotate. 
 * [Apipie](https://github.com/Apipie/apipie-rails) - Rails API documentation and display tool using Ruby syntax.
 * [Asciidoctor](https://asciidoctor.org) - A fast, Ruby-based text processor & publishing toolchain for converting AsciiDoc to HTML5, DocBook, EPUB3, PDF & more.
 * [Documentation](https://github.com/adamcooke/documentation) - A Rails engine to provide the ability to add documentation to a Rails application.

--- a/README.md
+++ b/README.md
@@ -587,7 +587,6 @@ Where to discover new Ruby libraries, projects and trends.
 
 ## Documentation
 
-* [Annotate](https://github.com/ctran/annotate_models) - Add a comment documenting the current schema to the top or bottom of each of your ActiveRecord models.
 * [AnnotateRb](https://github.com/drwl/annotaterb) - Adds database schema annotations for your ActiveRecord models as text comments as well as routes. An active and maintained hard fork of Annotate. 
 * [Apipie](https://github.com/Apipie/apipie-rails) - Rails API documentation and display tool using Ruby syntax.
 * [Asciidoctor](https://asciidoctor.org) - A fast, Ruby-based text processor & publishing toolchain for converting AsciiDoc to HTML5, DocBook, EPUB3, PDF & more.


### PR DESCRIPTION
## Project

Adds `AnnotateRb` gem to the list of gems.

[Rubygems](https://rubygems.org/gems/annotaterb)
[Github repo](https://github.com/drwl/annotaterb)

## What is this Ruby project?

It's an active and maintained hard fork of the old Annotate gem. It improves the developer experience by adding model database schemas as text comments in corresponding ActiveRecord models. It also supports annotating routes.

## What are the main difference between this Ruby project and similar ones?

It's actively maintained compared to it's predecessor, the Annotate gem.
