### PR TITLE
add trilogy library to database drivers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [SQLite3](https://github.com/sparklemotion/sqlite3-ruby) - Ruby bindings for the SQLite3 embedded database.
 * [SQL Server](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter) - The SQL Server adapter for ActiveRecord.
 * [TinyTDS](https://github.com/rails-sqlserver/tiny_tds) - FreeTDS bindings for Ruby using DB-Library.
+* [Trilogy](https://github.com/trilogy-libraries/trilogy) - A performance-oriented C library for MySQL-compatible databases.
 
 ## Database Tools
 


### PR DESCRIPTION
## Project
https://github.com/trilogy-libraries/trilogy

## Issue
https://github.com/markets/awesome-ruby/issues/1146

## What is this Ruby project?
It's modern MySQL adapter 
https://github.blog/open-source/maintainers/introducing-trilogy-a-new-database-adapter-for-ruby-on-rails/

The Trilogy adapter gets default support in Rails 7.1 https://rubyonrails.org/2023/9/13/Rails-7-1-0-beta-1-has-been-released

## What are the main difference between this Ruby project and similar ones?
It's a "modern" adapter for MySQL and it's receiving ongoing support through GitHub and Shopify