### PR TITLE
Add gitignore-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,6 +755,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [git-spelunk](https://github.com/osheroff/git-spelunk) - Dig through git blame history.
 * [git-whence](https://github.com/grosser/git-whence) - Find which merge a commit came from.
 * [Git Lint](https://www.alchemists.io/projects/git-lint) - Analyzes Git commits for consistent quality.
+* [gitignore-cli](https://github.com/dvinciguerra/gitignore-cli) - A cli tool that use gitignore.io to generate your gitignore files.
 * [Overcommit](https://github.com/brigade/overcommit) - A fully configurable and extendable Git hook manager.
 * [Rugged](https://github.com/libgit2/rugged) - Ruby bindings to libgit2.
 


### PR DESCRIPTION
Add gitignore-cli tool to generate .gitignore files using gitignore.io

## Project

gitignore-cli - https://github.com/dvinciguerra/gitignore-cli

## What is this Ruby project?

The gitignore CLI uses gitignore.io API to help developers to create .gitignore files in a simple way.

[![asciicast](https://asciinema.org/a/299023.svg)](https://asciinema.org/a/299023?autoplay=1&speed=2)


## What are the main difference between this Ruby project and similar ones?

- It's more updated than gitignore-gem
- It has a better interactive mode to list and select item than others too

---

Please help us to maintain this collection by using reactions (👍, 👎) and comments to express your feelings.
