### PR TITLE
Add ZMediumToMarkdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,6 +878,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [Maruku](https://github.com/bhollis/maruku) - A pure-Ruby Markdown-superset interpreter.
 * [Redcarpet](https://github.com/vmg/redcarpet) - A fast, safe and extensible Markdown to (X)HTML parser.
 * [word-to-markdown](https://github.com/benbalter/word-to-markdown) - Gem to convert Microsoft Word documents to Markdown.
+* [ZMediumToMarkdown](https://github.com/ZhgChgLi/ZMediumToMarkdown) - A powerful tool that allows you to effortlessly download and convert your Medium posts to Markdown format.
 
 ## Measurements
 


### PR DESCRIPTION
## Project

https://github.com/ZhgChgLi/ZMediumToMarkdown

## What is this Ruby project?

A powerful tool that allows you to effortlessly download and convert your Medium posts to Markdown format.

## What are the main difference between this Ruby project and similar ones?

ZMediumToMarkdown: Focuses on downloading and converting Medium posts to Markdown, ideal for users looking to archive or migrate their content.

---

Please help us to maintain this collection by using reactions (👍, 👎) and comments to express your feelings.
