### PR TITLE
Remove Sider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1226,7 +1226,6 @@ Online tools, services and APIs to simplify development.
 * [Inch CI](https://inch-ci.org/) - Documentation badges for Ruby projects.
 * [OctoLinker](https://github.com/OctoLinker/browser-extension) - Navigate through projects on GitHub.com efficiently with the OctoLinker browser extension.
 * [SemaphoreCI](https://semaphoreci.com) - Hosted continuous integration and deployment service for open source and private projects.
-* [Sider](https://sider.review/) - Automated Code Review with GitHub PR. Monitoring Style Violations, Quality, Security, Dependencies.
 * [Travis CI](https://travis-ci.com) - Test and Deploy Your Code with Confidence.
 
 ## SEO


### PR DESCRIPTION
The https://sider.review link is broken (404). Turns out Sider shut down in 2022.

Here's a tweet confirming it: https://x.com/sumyapp/status/1609398943594733568
related: https://github.com/markets/awesome-ruby/pull/494