### PR TITLE
Add PacketFu

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,6 +924,7 @@ Where to discover new Ruby libraries, projects and trends.
 
 * [Dnsruby](https://github.com/alexdalitz/dnsruby) - A pure Ruby DNS client library which implements a stub resolver. It aims to comply with all DNS RFCs.
 * [RubyDNS](https://github.com/ioquatix/rubydns) - A high-performance DNS server which can be easily integrated into other projects or used as a stand-alone daemon.
+* [PacketFu](https://github.com/packetfu/packetfu) - A library for reading and writing packets to an interface or to a libpcap-formatted file.
 
 ## Notifications
 


### PR DESCRIPTION
## Project

[PacketFu](https://github.com/packetfu/packetfu) is packet analysis library. It enables sniffing and injecting packets to an interface.

## What is this Ruby project?

This project is a decade old packet analysis library. It allows packet manipulation and dissection through high level  abstraction.

## What are the main difference between this Ruby project and similar ones?

This project is similar to the popular `Scapy` library for Python. I'm not sure whether a similar project exists for Ruby. 

This PR resolves #1157.