### PR TITLE
adds finrb gem under Money segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,6 +903,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [eu_central_bank](https://github.com/RubyMoney/eu_central_bank) - A gem that calculates the exchange rate using published rates from European Central Bank.
 * [Monetize](https://github.com/RubyMoney/monetize) - A library for converting various objects into Money objects.
 * [Money](https://github.com/RubyMoney/money) - A Ruby Library for dealing with money and currency conversion.
+* [finrb](https://github.com/ncs1/finrb) - Ruby gem for financial calculations/modeling.
 
 ## Music and Sound
 


### PR DESCRIPTION
## Project

finrb

- [RubyGems Page](https://rubygems.org/gems/finrb)
- [Source Code](https://github.com/ncs1/finrb)
- [Bug Tracker](https://github.com/ncs1/finrb/issues)

## What is this Ruby project?

Ruby gem for financial calculations/modeling.

finrb forked from the ruby [finance](https://github.com/Edward-Intelligence/finance) gem.

- Uses the [flt](https://github.com/jgoizueta/flt) gem to ensure precision decimal arithmetic in all calculations.
- Fixed-rate mortgage amortization (30/360).
- Interest rates
- Various cash flow computations, such as NPV and IRR.
- Adjustable rate mortgage amortization.
- Payment modifications (i.e., how does paying an additional $75 per month affect the amortization?)
- Utils class provides basic financial calculation utilities (ported from R's [FinCal](https://github.com/felixfan/FinCal) library)

## What are the main difference between this Ruby project and similar ones?

Maintained; and sadly there aren't other financial gems available.. even basic as this.

---

Please help us to maintain this collection by using reactions (👍, 👎) and comments to express your feelings.
