### PR TITLE
Add random-rails to the list of libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -956,6 +956,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [fast_underscore](https://github.com/kddeisz/fast_underscore) - Provides a C-optimized method for transforming a string from any capitalization into underscore-separated
 * [pluck_in_batches](https://github.com/fatkodima/pluck_in_batches) - A faster alternative to the custom use of `in_batches` with `pluck`.
 * [yajl-ruby](https://github.com/brianmario/yajl-ruby) - A streaming JSON parsing and encoding library for Ruby (C bindings to yajl).
+* [random-rails](https://github.com/the-rubies-way/random-rails) - The fastest solution for retrieving random ActiveRecord records, compatible with PostgreSQL, MySQL, and SQLite.
 
 ## ORM/ODM
 


### PR DESCRIPTION
## Project
**random-rails**

https://github.com/the-rubies-way/random-rails
https://rubygems.org/gems/random-rails

## What is this Ruby project?

It’s a small gem that lets you fetch random records in Rails with much better performance than ORDER BY RANDOM() or offset-based approaches.

It integrates nicely with ActiveRecord and is open source, so you can easily see how it works or adjust it for your needs.

## What are the main difference between this Ruby project and similar ones?

The main difference is performance and simplicity. Unlike many other gems that rely on ORDER BY RANDOM() or offset-based approaches—which can be very slow on large tables—this gem is optimized to fetch random records efficiently across supported databases (PostgreSQL, MySQL, SQLite).

It also integrates cleanly with ActiveRecord, works with scopes, and doesn’t require complex setup or custom SQL. The focus is on providing a fast, reliable, and easy-to-use solution for fetching random records in Rails.
