### PR TITLE
Add domain_extractor - URL parsing gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,6 +802,7 @@ Where to discover new Ruby libraries, projects and trends.
 ## HTTP Clients and tools
 
 * [Accept Language](https://github.com/cyril/accept_language.rb) - A tiny library for parsing the `Accept-Language` header from browsers (as defined in [RFC 2616](https://datatracker.ietf.org/doc/html/rfc2616#section-14.4)).
+* [Domain Extractor](https://github.com/opensite-ai/domain_extractor) - Lightweight Ruby gem for URL parsing and domain extraction with accurate multi-part TLD support.
 * [excon](https://github.com/excon/excon) - Usable, fast, simple Ruby HTTP 1.1. It works great as a general HTTP(s) client and is particularly well suited to usage in API clients.
 * [Faraday](https://github.com/lostisland/faraday) - an HTTP client lib that provides a common interface over many adapters (such as Net::HTTP) and embraces the concept of Rack middleware when processing the request/response cycle.
 * [Device Detector](https://github.com/podigee/device_detector) - A precise and fast user agent parser and device detector, backed by the largest and most up-to-date user agent database.


### PR DESCRIPTION
**Add domain_extractor - URL parsing gem**

## Project

- **GitHub:** https://github.com/opensite-ai/domain_extractor
- **RubyGems:** https://rubygems.org/gems/domain_extractor
- **Documentation:** https://rubydoc.info/gems/domain_extractor
- **Dev.to introduction:** https://dev.to/opensite/introducing-domainextractor-a-high-performance-ruby-gem-for-url-parsing-and-domain-extraction-3f4i
- **Project page:** https://opensite.ai/developers

## What is this Ruby project?

**domain_extractor** is a lightweight, production-ready Ruby gem for parsing URLs and extracting domain components—including support for multi-part TLDs (like `.co.uk`, `.com.au`, `.gov.br`). It delivers reliable domain, subdomain, root domain, and TLD extraction even from complex or deeply nested URLs. Built on top of Ruby's standard `URI` library and the `public_suffix` gem, it also provides features like:

- Query parameter parsing
- Smart URL normalization (handles missing schemes, ports, authentication, etc.)
- Precise edge-case handling (returns `nil` for invalid URLs or IP addresses)
- Thread safety and strong performance for analytics, scraping, and SEO workflows

## What are the main differences between this Ruby project and similar ones?

- **Accurate multi-part TLD support:** Uses the Public Suffix List for precise extraction; handles `.co.uk`, `.com.au`, `.gov.br`, and all recognized multi-part suffixes
- **Deep nested subdomain handling:** Correctly extracts subdomains of any depth with no configuration required
- **Zero config, instant use:** No setup or special methods needed; a single `parse(url)` handles almost any URL in the wild
- **Query parameter extraction:** Built-in parsing to structured hashes for tracking/analytics uses
- **Batch mode:** High-throughput batch parsing for handling large scraped datasets or logs
- **Well-documented and maintained:** Active open-source project with docs, benchmark data, and real production use at OpenSite AI
- **Compared to:**  
  - **psl-domain-extractor:** More user-friendly API, better documentation, broader TLD handling, and more active development
  - **root_domain:** More features (subdomain extraction, query parsing), better performance, and documentation
  - **URI/addressable (stdlib):** These libraries don't handle multi-part TLDs or provide robust domain separation

domain_extractor is ideal for anyone needing robust domain handling in Ruby apps—particularly use cases involving international URLs, analytics pipelines, and modern SEO.

---

Please help us to maintain this collection by using reactions (👍, 👎) and comments to express your feelings.