### PR TITLE
Add Textstat to Natural Language Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,6 +931,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [ruby-spellchecker](https://github.com/omohokcoj/ruby-spellchecker) - English spelling and grammar checker that can be used for autocorrection.
 * [Sentimental](https://github.com/7compass/sentimental) - Simple sentiment analysis with Ruby.
 * [Text](https://github.com/threedaymonk/text) - A collection of text algorithms including Levenshtein distance, Metaphone, Soundex 2, Porter stemming & White similarity.
+* [Textstat](https://github.com/kupolak/textstat) - Ruby gem for text readability analysis. Calculate readability statistics using 13 proven formulas (Flesch, SMOG, Coleman-Liau, etc.) with support for 22 languages.
 * [Treat](https://github.com/louismullie/treat) - Treat is a toolkit for natural language processing and computational linguistics in Ruby.
 * [Treetop](https://github.com/cjheath/treetop) - PEG (Parsing Expression Grammar) parser.
 * [Words Counted](https://github.com/abitdodgy/words_counted) - A highly customisable Ruby text analyser and word counter.


### PR DESCRIPTION
## Project

Textstat - Ruby gem for text readability analysis

GitHub: https://github.com/kupolak/textstat
RubyGems: https://rubygems.org/gems/textstat

## What is this Ruby project?

TextStat calculates readability statistics and complexity metrics from text using 13 proven formulas (Flesch Reading Ease, SMOG, Coleman-Liau, Gunning Fog, Dale-Chall, etc.). Supports 22 languages with language-specific dictionaries for accurate difficult word detection.

## What are the main difference between this Ruby project and similar ones?

Specialized for readability: Textstat focuses specifically on readability analysis with scientifically-validated formulas
True multi-language support: 22 languages with native dictionaries, not just English
Comprehensive formula coverage: 13 different readability formulas in one gem
Production-ready: Actively maintained (v1.0.1 - December 2025), extensive testing, backward compatible