### PR TITLE
- Add two popular Ruby gems:

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,6 +812,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [Http-2](https://github.com/igrigorik/http-2) - Pure Ruby implementation of HTTP/2 protocol
 * [Patron](https://github.com/toland/patron) - Patron is a Ruby HTTP client library based on libcurl.
 * [RESTClient](https://github.com/rest-client/rest-client) - Simple HTTP and REST client for Ruby, inspired by microframework syntax for specifying actions.
+* [Rack::Cors](https://github.com/cyu/rack-cors) - Cross-Origin Resource Sharing (CORS) middleware for Rack applications.
 * [Savon](https://github.com/savonrb/savon) - Savon is a SOAP client for the Ruby programming language.
 * [Sawyer](https://github.com/lostisland/sawyer) - Secret user agent of HTTP, built on top of Faraday.
 * [Sniffer](https://github.com/aderyabin/sniffer) – Tool to log and debug outgoing HTTP requests across multiple ruby libraries.
@@ -1015,6 +1016,8 @@ Where to discover new Ruby libraries, projects and trends.
   * [ActsAsList](https://github.com/swanandp/acts_as_list) - Provides the capabilities for sorting and reordering a number of objects in a list.
   * [positioning](https://github.com/brendon/positioning) - Simple positioning for Active Record models. Supports multiple lists per model and relative positioning.
   * [ranked-model](https://github.com/mixonic/ranked-model) - A modern row sorting library for ActiveRecord. It uses ARel aggressively and is better optimized than most other libraries.
+* Tagging
+  * [Acts As Taggable On](https://github.com/mbleigh/acts-as-taggable-on) - A tagging plugin for Rails applications that allows for custom tagging along dynamic contexts.
 * Tree
   * [ActsAsTree](https://github.com/amerine/acts_as_tree) - Extends ActiveRecord to add simple support for organizing items into parent–children relationships.
   * [ActsAsRecursiveTree](https://github.com/1and1/acts_as_recursive_tree) - ActsAsTree but recursive.


### PR DESCRIPTION
Add rack-cors and acts-as-taggable-on gems

Adds two popular Ruby gems:

1. Rack::Cors (238M+ Overall and  4M+ downloads for current version) - CORS middleware for Rack applications
   - Added to HTTP Clients and tools section
   - https://github.com/cyu/rack-cors

2. Acts As Taggable On (64M+ downloads overall and 6M+ on current version) - Tagging plugin for Rails
   - Added new "Tagging" subsection in ORM/ODM Extensions section
   - https://github.com/mbleigh/acts-as-taggable-on

Both gems meet the quality standards (30k+ downloads, actively maintained, well-documented).
