### PR TITLE
Add EasyTalk - JSON Schema generation library

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Blueprinter](https://github.com/procore/blueprinter) - Simple, Fast, and Declarative Serialization Library for Ruby.
 * [cache_crispies](https://github.com/codenoble/cache-crispies) - Speedy Rails JSON serialization with built-in caching.
 * [Crepe](https://github.com/crepe/crepe) - The thin API stack.
+* [EasyTalk](https://github.com/sergiobayona/easy_talk) - Define structured data models with a DSL that generates JSON Schema and ActiveModel validations from a single source of truth.
 * [Grape](http://www.ruby-grape.org) - An opinionated micro-framework for creating REST-like APIs in Ruby.
 * [Her](https://github.com/remiprev/her) - an ORM that maps REST resources to Ruby objects. Designed to build applications that are powered by a RESTful API instead of a database.
 * [jbuilder](https://github.com/rails/jbuilder) - Create JSON structures via a Builder-style DSL.


### PR DESCRIPTION
Adding EasyTalk to the API Builder and Discovery section.

## Project

**EasyTalk:** Define structured data models with a clean Ruby DSL that generates JSON Schema and ActiveModel validations from a single source of truth. Inspired by Python's Pydantic.

**Links:**
- GitHub: https://github.com/sergiobayona/easy_talk
- RubyGems: https://rubygems.org/gems/easy_talk
- Documentation: https://rubydoc.info/gems/easy_talk

## Qualification

- **Downloads:** 57,000+ total (exceeds 30k requirement)
- **Maintenance:** Actively maintained, v3.3.0 released January 2026
- **Ruby Version:** 3.2+
- **License:** MIT
- **Test Coverage:** Full CI with codecov integration

## Key Features

- Pydantic-style DSL for defining data models in Ruby
- Generates JSON Schema from class definitions
- Automatic ActiveModel validations from schema constraints
- Sorbet-style type system (`T.nilable`, `T::Array`, `T::OneOf`, etc.)
- LLM function/tool calling schema generation
- Nested model support with automatic instantiation
- Multiple error format outputs (RFC 7807, JSON:API)

## Why It Belongs

This fills a gap in the current list - there's no JSON Schema generation library. EasyTalk bridges API definition and validation, complementing existing serialization tools like jbuilder, Blueprinter, and JSONAPI::Resources by providing the schema definition layer.

## Checklist

- [x] Entry is alphabetically sorted
- [x] Description ends with a period
- [x] No trailing whitespace
- [x] Single link per PR
- [x] Searched for duplicates (none found)