### PR TITLE
Add wreq to HTTP Clients and tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [Sawyer](https://github.com/lostisland/sawyer) - Secret user agent of HTTP, built on top of Faraday.
 * [Sniffer](https://github.com/aderyabin/sniffer) – Tool to log and debug outgoing HTTP requests across multiple ruby libraries.
 * [Typhoeus](https://github.com/typhoeus/typhoeus) - Typhoeus wraps libcurl in order to make fast and reliable requests.
+* [wreq](https://github.com/SearchApi/wreq-ruby) - An HTTP client with real browser TLS/HTTP2 fingerprinting, emulating Chrome, Firefox, Safari, Edge, and Opera signatures via BoringSSL.
 
 ## Image Processing
 


### PR DESCRIPTION
[wreq](https://github.com/SearchApi/wreq-ruby) is the first production-ready Ruby HTTP client with real browser TLS/HTTP2 fingerprinting. It emulates exact signatures of Chrome, Firefox, Safari, Edge, Opera, and OkHttp.

Modern anti-bot systems identify HTTP clients by their TLS and HTTP2 fingerprints (JA3/JA4). Every HTTP client currently listed in this section — Faraday, HTTParty, HTTP, HTTPX, Typhoeus, Patron, RESTClient, excon — relies on either OpenSSL or libcurl compiled with OpenSSL. Even curl-based libraries like Typhoeus and Patron inherit curl's TLS stack limitations. None of them provide control over TLS extension ordering, cipher suite ordering, or HTTP/2 frame settings needed to match real browser signatures.

wreq-ruby solves this using BoringSSL (the same TLS library Chrome uses), powered by Rust via the [wreq](https://github.com/0x676e67/wreq) crate, built in collaboration with the original maintainer.

- Pre-compiled native gems for Linux (x86_64, aarch64) and macOS (arm64) — no Rust toolchain needed
- Supports the latest Ruby versions
- Used in production at [SearchApi](https://www.searchapi.io/), where we are actively investing in its development and long-term support