### PR TITLE
Add ReleaseRun Ruby Gems Health checker to Code Analysis and Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 
 ## Code Analysis and Metrics
 
+* [ReleaseRun Ruby Gems Health](https://releaserun.com/tools/ruby-gems-health/) - A free web tool that checks any RubyGem for latest version, total downloads, last-updated date, and an A–F maintenance health grade.
 * [Brakeman](https://github.com/presidentbeef/brakeman) - A static analysis security vulnerability scanner for Ruby on Rails applications.
 * [Coverband](https://github.com/danmayer/coverband) - Rack middleware to help measure production code coverage.
 * [Fasterer](https://github.com/DamirSvrtan/fasterer) - Make your Rubies go faster with this command line tool highly inspired by fast-ruby and Sferik's talk at Baruco Conf.


### PR DESCRIPTION
Adds a free web tool for checking Ruby gem health — latest version, total downloads, how recently updated, and A–F health grade. Useful for auditing Gemfile dependencies.

URL: https://releaserun.com/tools/ruby-gems-health/