### PR TITLE
Add ReleaseRun — free Gemfile and RubyGems health checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Strong Migrations](https://github.com/ankane/strong_migrations) - Catch unsafe migrations in development.
 * [Upsert](https://github.com/seamusabshere/upsert) - Upsert on MySQL, PostgreSQL, and SQLite3. Transparently creates functions (UDF) for MySQL and PostgreSQL; on SQLite3, uses INSERT OR IGNORE.
 
+- [ReleaseRun](https://releaserun.com) — free Gemfile and RubyGems health checker — scans for ruby-advisory-db CVEs and outdated gems
 ## Date and Time Processing
 
 * [biz](https://github.com/zendesk/biz) - Time calculations using business hours.


### PR DESCRIPTION
**ReleaseRun** (https://releaserun.com) provides free browser-based tools for Ruby dependency health:

- **Gemfile Health Checker** — scans against ruby-advisory-db for CVEs and outdated gems
- **RubyGems Health Checker** — individual gem version and CVE check
- **Ruby + Rails EOL Calendar** — version support windows for Ruby and Rails

No signup or installation. Paste your Gemfile, get results instantly.