### PR TITLE
Add rspec-tracer (test-skip caching + dependency tracking for RSpec)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1358,6 +1358,7 @@ Online tools, services and APIs to simplify development.
   * [Parallel Tests](https://github.com/grosser/parallel_tests) - Speedup Test::Unit + RSpec + Cucumber by running parallel on multiple CPUs (or cores).
   * [power_assert](https://github.com/k-tsj/power_assert) - Power Assert for Ruby.
   * [Ruby-JMeter](https://github.com/flood-io/ruby-jmeter) - A Ruby based DSL for building JMeter test plans.
+  * [rspec-tracer](https://github.com/avmnu-sng/rspec-tracer) - Specs dependency analyzer, flaky tests detector, tests accelerator, and coverage reporter for RSpec
   * [Spring](https://github.com/rails/spring) - Preloads your rails environment in the background for faster testing and Rake tasks.
   * [timecop](https://github.com/travisjeffery/timecop) - Provides "time travel" and "time freezing" capabilities, making it dead simple to test time-dependent code.
   * [Turbo Tests](https://github.com/serpapi/turbo_tests) - Run RSpec tests on multiple cores. Like `parallel_tests` but with incremental summarized output.


### PR DESCRIPTION
## Project

RSpec Tracer https://github.com/avmnu-sng/rspec-tracer

## What is this Ruby project?

It tracks which source files each RSpec example depends on, so subsequent runs skip examples whose tracked inputs didn't change. Cold run: everything runs. Warm run with no edits: nothing runs. Edit one file; only the examples that depend on that file should rerun.

## What are the main difference between this Ruby project and similar ones?

Niche but real; there's no other dependency-tracking RSpec gem in the same shape (rspec-retry / rspec-rerun solve different problems).