### PR TITLE
Add Inkmark (Markdown processors)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Autoprefixer](https://github.com/ai/autoprefixer-rails) - Parse CSS and add vendor prefixes to rules by Can I Use.
 * [Bourbon](https://github.com/thoughtbot/bourbon) - A Lightweight Sass Tool Set.
 * [bower-rails](https://github.com/rharriso/bower-rails) - Bower support for Rails projects.
+* [Bundlebun](https://github.com/yaroslav/bundlebun) - bundles Bun, the all-in-one JavaScript runtime, package manager, and build tool, directly into your Ruby gem bundle.
 * [Emoji](https://github.com/wpeterson/emoji) - Exposes the Phantom Open Emoji library unicode/image assets and APIs for working with them.
 * [Less Rails](https://github.com/metaskills/less-rails) - The dynamic stylesheet language for the Rails asset pipeline.
 * [Rails Assets](https://rails-assets.org) - Bundler to Bower proxy.

--- a/README.md
+++ b/README.md
@@ -894,6 +894,7 @@ Where to discover new Ruby libraries, projects and trends.
 
 ## Markdown Processors
 
+* [Inkmark](https://github.com/yaroslav/inkmark) - A very fast, feature-packed, AI-first Markdown (CommonMark/GFM) gem for Ruby.
 * [kramdown](https://github.com/gettalong/kramdown) - Kramdown is yet-another-markdown-parser but fast, pure Ruby, using a strict syntax definition and supporting several common extensions.
 * [markdown_helper](https://github.com/BurdetteLamar/markdown_helper#markdown-helper) - A markdown pre-processor implementing file inclusion and page TOC (table of contents).
 * [Maruku](https://github.com/bhollis/maruku) - A pure-Ruby Markdown-superset interpreter.


### PR DESCRIPTION
## Project

Inkmark (https://github.com/yaroslav/inkmark)

## What is this Ruby project?

A very fast, feature-packed, AI-first Markdown (CommonMark/GFM) gem for Ruby, based on pulldown-cmark (Rust).

## What are the main difference between this Ruby project and similar ones?

Speed. Leads on benchmarks (see `README`).
Features. Boasts more features than any Ruby markdown processor.
AI-first features. Several features specifically designed for RAG pipelines.

---

Please help us to maintain this collection by using reactions (👍, 👎) and comments to express your feelings.
