### PR TITLE
Add fastlane-plugin-pgyer to Mobile Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,6 +910,7 @@ Where to discover new Ruby libraries, projects and trends.
 
 * [dryrun](https://github.com/cesarferreira/dryrun) - Try any Android library on your smartphone directly from the command line.
 * [fastlane](https://github.com/fastlane/fastlane) - Connect all iOS deployment tools into one streamlined workflow.
+* [fastlane-plugin-pgyer](https://github.com/PGYER/fastlane-plugin-pgyer) - Distribute iOS, Android and HarmonyOS apps to PGYER beta testing service from your Fastlane lane.
 * [PubNub](https://github.com/pubnub/ruby) - Real-time Push Service in the Cloud.
 * [Ruboto](https://github.com/ruboto/ruboto) - A platform for developing full stand-alone apps for Android using the Ruby language and libraries.
 * [RubyMotion](http://www.rubymotion.com) - A revolutionary toolchain that lets you quickly develop and test full-fledged native iOS and OS X applications for iPhone, iPad, Mac and Android.


### PR DESCRIPTION
Adding [`fastlane-plugin-pgyer`](https://github.com/PGYER/fastlane-plugin-pgyer) to the **Mobile Development** section, placed alphabetically between `fastlane` and `PubNub`.

## What it is

The official Fastlane plugin for [PGYER (蒲公英)](https://www.pgyer.com), letting iOS, Android, and HarmonyOS developers automate beta-build uploads from their Fastlane lane. PGYER is China's leading mobile beta-distribution platform (the local equivalent of TestFlight/Firebase App Distribution), serving hundreds of thousands of mobile developers since 2014.

## Quality bar

- **30k+ downloads requirement**: 165,000+ total downloads on [RubyGems](https://rubygems.org/gems/fastlane-plugin-pgyer).
- **Actively maintained**: latest commit December 2025; vendor-maintained by the PGYER GitHub organization.
- **Stable**: 66 stars, MIT-licensed, 5 contributors.
- **Documented**: README covers install, usage, all parameters.
- **Tests**: ships with RSpec test suite.

## Entry format

Follows the list's existing format:

` * [fastlane-plugin-pgyer](https://github.com/PGYER/fastlane-plugin-pgyer) - Distribute iOS, Android and HarmonyOS apps to PGYER beta testing service from your Fastlane lane.`

## Checklist

- [x] Searched previous suggestions — not a duplicate.
- [x] Uses the `[Library](url) - Description.` format.
- [x] Link is the package name.
- [x] Sorted alphabetically within Mobile Development.
- [x] One link per PR.
- [x] Description is concise and ends with a period.
- [x] Spelling and grammar checked.
- [x] No trailing whitespace.