### PR TITLE
Add eu-vat-rates-data to Country Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 
 * [Carmen](https://github.com/jim/carmen) - A repository of geographic regions.
 * [Countries](https://github.com/hexorx/countries) - All sorts of useful information about every country packaged as pretty little country objects.
+* [eu-vat-rates-data](https://github.com/vatnode/eu-vat-rates-data) - EU VAT rates for 44 European countries (standard, reduced, super-reduced, parking), auto-synced daily from the European Commission's TEDB.
 * [i18n_data](https://github.com/grosser/i18n_data) - country/language names and 2-letter-code pairs, in 85 languages, for country/language i18n.
 * [normalize_country](https://github.com/sshaw/normalize_country) - Convert country names and codes to a standard, includes a conversion program for XMLs, CSVs and DBs.
 * [Phonelib](https://github.com/daddyz/phonelib) - Ruby gem for phone validation and formatting using Google libphonenumber library data.


### PR DESCRIPTION
Adding [eu-vat-rates-data](https://github.com/vatnode/eu-vat-rates-data) — a MIT-licensed dataset of VAT rates for 44 European countries, auto-synced daily from the European Commission's official TEDB SOAP service.

The Ruby gem is published as `eu-vat-rates-data` on RubyGems and exposes a small API to fetch all rates, get a specific country's standard rate, or check EU membership. Fits naturally alongside Countries / i18n_data / normalize_country in the Country Data section since VAT rates are a core piece of country-level metadata that's painful to keep current (e.g., Finland raised its standard rate from 24% to 25.5% in September 2024).

- MIT license
- Updated daily via GitHub Actions
- No API key, no telemetry
- Also published to npm, PyPI, Packagist, and Go modules

Placed alphabetically between Countries and i18n_data. Happy to adjust wording if needed.