### PR TITLE
Add Ezlogs to Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,6 +866,7 @@ Where to discover new Ruby libraries, projects and trends.
 
 ## Logging
 
+* [Ezlogs](https://github.com/dezsirazvan/ez_logs_agent) - Plain-English activity logs from HTTP, jobs, and DB callbacks — readable by non-developers.
 * [Fluentd](https://github.com/fluent/fluentd) - Fluentd collects events from various data sources and writes them to files, database or other types of storages.
 * [HttpLog](https://github.com/trusche/httplog) - Log outgoing HTTP requests.
 * [Log4r](https://github.com/colbygk/log4r) - Log4r is a comprehensive and flexible logging library for use in Ruby programs.


### PR DESCRIPTION
Adds **Ezlogs** to the Logging section, alphabetically first.

* [Ezlogs](https://github.com/dezsirazvan/ez_logs_agent) - Plain-English activity logs from HTTP, jobs, and DB callbacks — readable by non-developers.

Drop-in gem (`bundle add ez_logs_agent`) that captures Rails app activity — HTTP requests, Sidekiq / ActiveJob, and DB callbacks — and ships them to the EZLogs server, which renders them as plain-English activity logs that anyone on the team can read (not just developers). MIT-licensed, [actively maintained](https://rubygems.org/gems/ez_logs_agent), 854 specs.

Differentiates from existing entries in this section:
- Lograge (structured request logs) is logs-as-data for engineers; Ezlogs is logs-as-story for the whole team.
- Fluentd / Syslogger / Logging move log lines around; Ezlogs captures and *summarises* business events.