### PR TITLE
Add money-unirate-api to Money section

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,6 +920,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [eu_central_bank](https://github.com/RubyMoney/eu_central_bank) - A gem that calculates the exchange rate using published rates from European Central Bank.
 * [Monetize](https://github.com/RubyMoney/monetize) - A library for converting various objects into Money objects.
 * [Money](https://github.com/RubyMoney/money) - A Ruby Library for dealing with money and currency conversion.
+* [money-unirate-api](https://github.com/UniRate-API/money-unirate-api) - A Money::Bank implementation that fetches live exchange rates from the UniRate API.
 
 ## Music and Sound
 


### PR DESCRIPTION
## Summary

Adds [money-unirate-api](https://github.com/UniRate-API/money-unirate-api) to the **Money** section.

`money-unirate-api` is a `Money::Bank` implementation that fetches live exchange rates from the [UniRate API](https://unirateapi.com). It derives cross-pair rates on demand from a single-base snapshot, so stale cached pairs can't be served after a TTL refresh.

- Published on RubyGems: https://rubygems.org/gems/money-unirate-api
- 22 RSpec mock tests, CI green on Ruby 3.0–3.4
- Zero runtime deps beyond `money` (>= 6.13, < 7)
- Documented README with usage examples

Complements the existing `eu_central_bank`, `Monetize`, and `Money` entries in the section.

**Disclosure:** I'm the maintainer of the UniRate API and this gem.