### PR TITLE
Add leakferret to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -1237,6 +1237,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [bundler-audit](https://github.com/rubysec/bundler-audit) - Patch-level security verification for Bundler.
 * [Fingerprinter](https://github.com/erwanlr/Fingerprinter) - CMS/LMS/Library etc versions fingerprinter.
 * [haiti](https://github.com/noraj/haiti) - Hash type identifier (CLI & lib).
+* [leakferret](https://github.com/leakferrethq/leakferret-ruby) - Context-aware secret scanner. Finds hardcoded secrets, verifies which are live by calling the provider, and rewrites them to read from ENV.
 * [Metasploit](https://github.com/rapid7/metasploit-framework) - World's most used penetration testing software.
 * [Pipal](https://github.com/digininja/pipal) - Password analyser and statistics generator
 * [Rack::Attack](https://github.com/kickstarter/rack-attack) - Rack middleware for blocking & throttling abusive requests.


### PR DESCRIPTION
Adds [leakferret](https://github.com/leakferrethq/leakferret-ruby), an open-source, context-aware secret scanner available as a Ruby gem (`gem install leakferret`).

It finds hardcoded secrets, verifies which ones are actually live by calling the provider (rather than only pattern-matching), and rewrites the leak to read from ENV. It also ships a CLI and an MCP server. MIT licensed.

Placed alphabetically in the Security section.