### PR TITLE
feat: add TWZRD Agent Intel to Cryptocurrencies and Blockchains

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Ciri](https://github.com/ciri-ethereum/ciri) - Ruby implementation of Ethereum.
 * [MoneyTree](https://github.com/GemHQ/money-tree) - A Ruby implementation of Bitcoin HD Wallets (Hierarchical Deterministic) BIP32.
 * [Peatio](https://github.com/rubykube/peatio) - Most Advanced Cryptocurrency open-source assets exchange.
+* [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring MCP server for AI agents on Solana. Verify agent wallet identity before x402 micropayments.
 
 ## Dashboards
 


### PR DESCRIPTION
## What this adds

[TWZRD Agent Intel](https://intel.twzrd.xyz) — trust scoring MCP server for AI agents on Solana.

Provides on-chain trust scores for AI agent wallets operating on Solana. Used to verify agent wallet identity before x402 micropayments. Free MCP endpoint available.

Fits in the **Cryptocurrencies and Blockchains** section alongside other blockchain tools.

**Checklist**:
- [x] Format matches existing entries: `* [Name](url) - Description.`
- [x] Description is concise and non-promotional
- [x] Project is live and actively maintained