### PR TITLE
Add crawlberg, html-to-markdown, liter-llm, xberg (Ruby bindings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,6 +899,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [AI4R](https://github.com/sergiofierens/ai4r) - Algorithms covering several Artificial intelligence fields.
 * [Awesome Machine Learning with Ruby](https://github.com/arbox/machine-learning-with-ruby) - A Curated List of Ruby Machine Learning Links and Resources.
 * [langchain.rb](https://github.com/patterns-ai-core/langchainrb) - Library for building LLM-powered applications in Ruby.
+* [liter-llm](https://github.com/xberg-io/liter-llm) - Universal LLM API client (Ruby binding over a Rust core) with one unified interface across 142+ providers and streaming.
 * [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool to transpile trained classic ML models into a native Ruby code with zero dependencies.
 * [PredictionIO Ruby SDK](https://github.com/PredictionIO/PredictionIO-Ruby-SDK) - The PredictionIO Ruby SDK provides a convenient API to quickly record your users' behavior and retrieve personalized predictions for them.
 * [rb-libsvm](https://github.com/febeling/rb-libsvm) - Ruby language bindings for LIBSVM. SVM is a machine learning and classification algorithm.
@@ -911,6 +912,7 @@ Where to discover new Ruby libraries, projects and trends.
 
 ## Markdown Processors
 
+* [html-to-markdown](https://github.com/xberg-io/html-to-markdown) - Fast, CommonMark-compliant HTML to Markdown converter (Ruby binding over a Rust core).
 * [kramdown](https://github.com/gettalong/kramdown) - Kramdown is yet-another-markdown-parser but fast, pure Ruby, using a strict syntax definition and supporting several common extensions.
 * [markdown_helper](https://github.com/BurdetteLamar/markdown_helper#markdown-helper) - A markdown pre-processor implementing file inclusion and page TOC (table of contents).
 * [Maruku](https://github.com/bhollis/maruku) - A pure-Ruby Markdown-superset interpreter.
@@ -1294,6 +1296,7 @@ Online tools, services and APIs to simplify development.
 * [Docsplit](http://documentcloud.github.io/docsplit) - Gem to convert Microsoft Word (and other) documents into images, pdf, pages or text.
 * [Roo](https://github.com/roo-rb/roo) - Implements read access for all spreadsheet types and read/write access for Google spreadsheets.
 * [spreadsheet_architect](https://github.com/westonganger/spreadsheet_architect) - Spreadsheet Architect is a library that allows you to create XLSX, ODS, or CSV spreadsheets super easily from ActiveRecord relations, plain Ruby objects, or tabular data.
+* [xberg](https://github.com/xberg-io/xberg) - Document intelligence library (Ruby binding over a Rust core) that extracts text, tables, and metadata from PDFs, Office documents, images, and 97+ formats, with optional OCR.
 
 ## State Machines
 
@@ -1443,6 +1446,7 @@ Online tools, services and APIs to simplify development.
 
 ## Web Crawling
 
+* [crawlberg](https://github.com/xberg-io/crawlberg) - High-performance web crawling and scraping engine (Ruby binding over a Rust core) with HTML-to-Markdown conversion and a headless-Chrome fallback.
 * [LinkThumbnailer](https://github.com/gottfrois/link_thumbnailer) - Ruby gem that generates thumbnail images and videos from a given URL. Much like popular social website with link preview.
 * [Kimurai](https://github.com/vifreefly/kimuraframework) - A modern web scraping framework written in Ruby which works out of box with Headless Chromium/Firefox, PhantomJS, or simple HTTP requests and allows to scrape and interact with JavaScript rendered websites.
 * [Mechanize](https://github.com/sparklemotion/mechanize) - Mechanize is a ruby library that makes automated web interaction easy.


### PR DESCRIPTION
Adds four xberg-io libraries that ship native Ruby bindings (Rust core, MIT). Each is placed alphabetically in its section:

- **Web Crawling** — crawlberg (crawling/scraping engine, HTML→Markdown, headless-Chrome fallback)
- **Markdown Processors** — html-to-markdown (CommonMark HTML→Markdown converter)
- **Machine Learning** — liter-llm (universal LLM API client, 142+ providers)
- **Spreadsheets and Documents** — xberg (document intelligence: text/tables/metadata from 97+ formats with OCR)
