### PR TITLE
Add liter-llm to Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,6 +899,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [AI4R](https://github.com/sergiofierens/ai4r) - Algorithms covering several Artificial intelligence fields.
 * [Awesome Machine Learning with Ruby](https://github.com/arbox/machine-learning-with-ruby) - A Curated List of Ruby Machine Learning Links and Resources.
 * [langchain.rb](https://github.com/patterns-ai-core/langchainrb) - Library for building LLM-powered applications in Ruby.
+* [liter-llm](https://github.com/xberg-io/liter-llm) - Universal LLM API client (Ruby binding over a Rust core) with one unified interface across 142+ providers and streaming.
 * [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool to transpile trained classic ML models into a native Ruby code with zero dependencies.
 * [PredictionIO Ruby SDK](https://github.com/PredictionIO/PredictionIO-Ruby-SDK) - The PredictionIO Ruby SDK provides a convenient API to quickly record your users' behavior and retrieve personalized predictions for them.
 * [rb-libsvm](https://github.com/febeling/rb-libsvm) - Ruby language bindings for LIBSVM. SVM is a machine learning and classification algorithm.

--- a/README.md
+++ b/README.md
@@ -909,6 +909,7 @@ Where to discover new Ruby libraries, projects and trends.
 
 * [AI4R](https://github.com/sergiofierens/ai4r) - Algorithms covering several Artificial intelligence fields.
 * [Awesome Machine Learning with Ruby](https://github.com/arbox/machine-learning-with-ruby) - A Curated List of Ruby Machine Learning Links and Resources.
+* [liter-llm](https://github.com/xberg-io/liter-llm) - Universal LLM API client (Ruby binding over a Rust core) with one unified interface across 142+ providers and streaming.
 * [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool to transpile trained classic ML models into a native Ruby code with zero dependencies.
 * [rb-libsvm](https://github.com/febeling/rb-libsvm) - Ruby language bindings for LIBSVM. SVM is a machine learning and classification algorithm.
 * [ruby-fann](https://github.com/tangledpath/ruby-fann) - Ruby library for interfacing with FANN (Fast Artificial Neural Network).


### PR DESCRIPTION
Add liter-llm to Machine Learning. Ruby binding (RubyGems) over a Rust core, MIT. One link per PR per CONTRIBUTING.
