### PR TITLE
Add xberg to Spreadsheets and Documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1294,6 +1294,7 @@ Online tools, services and APIs to simplify development.
 * [Docsplit](http://documentcloud.github.io/docsplit) - Gem to convert Microsoft Word (and other) documents into images, pdf, pages or text.
 * [Roo](https://github.com/roo-rb/roo) - Implements read access for all spreadsheet types and read/write access for Google spreadsheets.
 * [spreadsheet_architect](https://github.com/westonganger/spreadsheet_architect) - Spreadsheet Architect is a library that allows you to create XLSX, ODS, or CSV spreadsheets super easily from ActiveRecord relations, plain Ruby objects, or tabular data.
+* [xberg](https://github.com/xberg-io/xberg) - Document intelligence library (Ruby binding over a Rust core) that extracts text, tables, and metadata from PDFs, Office documents, images, and 97+ formats, with optional OCR.
 
 ## State Machines
 


### PR DESCRIPTION
Add xberg to Spreadsheets and Documents. Ruby binding (RubyGems) over a Rust core, MIT. One link per PR per CONTRIBUTING.
