### PR TITLE
Add spikard to Web Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1465,6 +1465,7 @@ Online tools, services and APIs to simplify development.
 * [Ruby on Rails](http://rubyonrails.org) - A web-application framework that includes everything needed to create database-backed web applications according to the Model-View-Controller (MVC) pattern.
 * [Scorched](http://scorchedrb.com) - Light-weight, inheritable and composable web framework, inspired by Sinatra.
 * [Sinatra](http://www.sinatrarb.com) - Classy web-development dressed in a DSL.
+* [spikard](https://github.com/Goldziher/spikard) - Rust-powered polyglot HTTP framework with type-safe routing, tower middleware, and OpenAPI/GraphQL/JSON-RPC codegen (Ruby binding over a Rust core).
 * [Syro](https://github.com/soveran/syro/) - Simple router for web applications.
 * [Trailblazer](https://github.com/trailblazer/trailblazer) - Trailblazer is a thin layer on top of Rails. It gently enforces encapsulation, an intuitive code structure and gives you an object-oriented architecture.
 


### PR DESCRIPTION
Adds **spikard** (github.com/Goldziher/spikard, MIT, 103★) — a Rust-powered polyglot HTTP framework with type-safe routing, tower-http middleware, OpenAPI/AsyncAPI/GraphQL/JSON-RPC codegen, and WebSocket/SSE, exposed via a native Ruby binding.
