### PR TITLE
Add RubyLLM to Machine Learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,6 +903,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [PredictionIO Ruby SDK](https://github.com/PredictionIO/PredictionIO-Ruby-SDK) - The PredictionIO Ruby SDK provides a convenient API to quickly record your users' behavior and retrieve personalized predictions for them.
 * [rb-libsvm](https://github.com/febeling/rb-libsvm) - Ruby language bindings for LIBSVM. SVM is a machine learning and classification algorithm.
 * [ruby-fann](https://github.com/tangledpath/ruby-fann) - Ruby library for interfacing with FANN (Fast Artificial Neural Network).
+* [RubyLLM](https://github.com/crmne/ruby_llm) - A delightful Ruby way to work with AI, providing one unified interface to OpenAI, Anthropic, Gemini, and other LLM providers.
 * [ruby-openai](https://github.com/alexrudall/ruby-openai) - OpenAI API + Ruby!
 * [rumale](https://github.com/yoshoku/rumale) - A machine learning library with interfaces similar to Scikit-Learn.
 * [TensorFlow](https://github.com/ankane/tensorflow) - The end-to-end machine learning platform for Ruby.


### PR DESCRIPTION
## Project

* [RubyLLM](https://github.com/crmne/ruby_llm)

## What is this Ruby project?

Adds [RubyLLM](https://github.com/crmne/ruby_llm) to the Machine Learning section, a unified Ruby interface to OpenAI, Anthropic, Gemini, and other LLM providers. It offers a single, convention-over-configuration API for chat, streaming, tool/function calling, embeddings, and image generation, with first-class Rails integration.

## What are the main difference between this Ruby project and similar ones?

Unlike [ruby-openai](https://github.com/alexrudall/ruby-openai), which targets a single provider, RubyLLM exposes one consistent interface across many providers (OpenAI, Anthropic, Gemini, DeepSeek, Ollama, and more), so switching models is a one-line change. Compared to [langchain.rb](https://github.com/patterns-ai-core/langchainrb), it stays deliberately lightweight and focused on a clean idiomatic API rather than a broad framework of abstractions.