### PR TITLE
Add Dentaku to Business logic section

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 ## Business logic
 
 * [ActiveInteraction](https://github.com/AaronLasseigne/active_interaction) - Manage application specific business logic.
+* [Dentaku](https://github.com/rubysolo/dentaku) - A parser and evaluator for mathematical and logical formulas, safely evaluating user-supplied expressions at runtime.
 * [Interactor](https://github.com/collectiveidea/interactor) - Interactor provides a common interface for performing complex interactions in a single request.
 * [Light Service](https://github.com/adomokos/light-service) - Series of Actions with an emphasis on simplicity.
 * [Mutations](https://github.com/cypriss/mutations) - Compose your business logic into commands that sanitize and validate input.


### PR DESCRIPTION
## Project

  * [Dentaku](https://github.com/rubysolo/dentaku)

## What is this Ruby project?

Adds [Dentaku](https://github.com/rubysolo/dentaku) to the Business logic section, a parser and evaluator for mathematical and logical formulas. It safely evaluates user-supplied expressions (e.g. `"price * quantity * (1 - discount)"`) against a set of variables at runtime, without resorting to `eval`.

## What are the main difference between this Ruby project and similar ones?

Dentaku fills a niche, it evaluates configurable formulas provided as data (from users, config, or a database). It ships its own tokenizer and parser so expressions are evaluated in a sandbox rather than as executed Ruby, making it safe for untrusted input.

---

Please help us to maintain this collection by using reactions (👍, 👎) and comments to express your feelings.
