### PR TITLE
Add rv to Environment Management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [rbenv](https://github.com/sstephenson/rbenv) - Use rbenv to pick a Ruby version for your application and guarantee that your development environment matches production.
 * [ruby-build](https://github.com/sstephenson/ruby-build) - Compile and install Ruby.
 * [ruby-install](https://github.com/postmodern/ruby-install) - Installs Ruby, JRuby, Rubinius, MagLev or MRuby.
+* [rv](https://rv.dev) - A fast Ruby version and toolchain manager written in Rust.
 * [RVM](https://rvm.io) - RVM is a command-line tool which allows you to easily install, manage, and work with multiple ruby environments from interpreters to sets of gems.
 * [Tokaido](https://github.com/tokaido/tokaidoapp/releases) - Ruby, Rails, SQLite and Redis encapsulated in a single drag-and-drop OS X app, designed to make installing a working RoR environment easy for beginners.
 * [Uru](https://bitbucket.org/jonforums/uru) - Uru is a lightweight, multi-platform command line tool that helps you use the multiple rubies on your 32/64-bit Linux, OS X, or Windows systems.


### PR DESCRIPTION
## Project

  * [rv](https://rv.dev)

## What is this Ruby project?

Adds [rv](https://rv.dev) to the Environment Management section, a fast Ruby version and toolchain manager written in Rust, for installing and switching between multiple Ruby versions.

## What are the main difference between this Ruby project and similar ones?

Unlike shell-based managers such as RVM, rbenv, and chruby, rv is a single self-contained binary written in Rust with no shell shims or runtime overhead. It focuses on fast, reproducible Ruby installs and project-level version selection, in the spirit of tools like [`uv`](https://docs.astral.sh/uv/) for Python.

---

Please help us to maintain this collection by using reactions (👍, 👎) and comments to express your feelings.
