### PR TITLE
Add rubydex to Code Analysis and Metrics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [rails_best_practices](https://github.com/railsbp/rails_best_practices) - A code metric tool for rails projects.
 * [Reek](https://github.com/troessner/reek) - Code smell detector for Ruby.
 * [Rubycritic](https://github.com/whitesmith/rubycritic) - A Ruby code quality reporter.
+* [rubydex](https://github.com/Shopify/rubydex) - A high-performance static analysis suite for Ruby, built in Rust with Ruby APIs.
 * [Scientist](https://github.com/github/scientist) - A Ruby library for carefully refactoring critical paths.
 * [SimpleCov](https://github.com/colszowka/simplecov) - Code coverage for Ruby 1.9+ with a powerful configuration library and automatic merging of coverage across test suites.
 * [Sorbet](https://github.com/sorbet/sorbet) - A static type checker for Ruby.


### PR DESCRIPTION
## Project

* [rubydex](https://github.com/Shopify/rubydex)


## What is this Ruby project?

Adds [rubydex](https://github.com/Shopify/rubydex) to the Code Analysis and Metrics section, a high-performance static analysis suite for Ruby, built in Rust and exposed through Ruby APIs. It provides fast indexing and analysis of Ruby code, intended as a foundation for tooling like linters, language servers, and refactoring tools.

## What are the main difference between this Ruby project and similar ones?

Unlike pure-Ruby analyzers such as Reek or RubyCritic, rubydex is implemented in Rust for speed, focusing on high-throughput indexing and static analysis of large codebases while still being consumable from Ruby. Rather than reporting a fixed set of code smells or metrics, it aims to be a reusable analysis foundation that other developer tools can build on.


## Links

* https://shopify.github.io/rubydex/
* https://railsatscale.com/2026-05-12-one-engine-many-tools/

---

Please help us to maintain this collection by using reactions (👍, 👎) and comments to express your feelings.
