### PR TITLE
Add Pay and PayPal Server SDK to E-Commerce and Payments section

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,8 @@ Where to discover new Ruby libraries, projects and trends.
 * [Braintree](https://github.com/braintree/braintree_ruby) - Braintree Ruby bindings.
 * [Conekta](https://github.com/conekta/conekta-ruby) - Conekta Ruby bindings.
 * [credit_card_validations](https://github.com/didww/credit_card_validations) - A ruby gem for validating credit card numbers, generating valid numbers, Luhn checks.
+* [Pay](https://github.com/pay-rails/pay) - A payments engine for Rails, supporting Stripe, Braintree, Paddle, and Lemon Squeezy.
+* [PayPal Server SDK](https://github.com/paypal/PayPal-Ruby-Server-SDK) - PayPal's official Ruby SDK for the PayPal Server APIs (Orders and Payments).
 * [ROR Ecommerce](https://github.com/drhenner/ror_ecommerce) - A Rails e-commerce platform.
 * [Solidus](https://github.com/solidusio/solidus) - An open source, eCommerce application for high volume retailers.
 * [Spree](https://github.com/spree/spree) - Spree is a complete open source e-commerce solution for Ruby on Rails.


### PR DESCRIPTION
## Project

* [Pay](https://github.com/pay-rails/pay) - A payments engine for Rails, supporting Stripe, Braintree, Paddle, and Lemon Squeezy.
* [PayPal Server SDK](https://github.com/paypal/PayPal-Ruby-Server-SDK) - PayPal's official Ruby SDK for the PayPal Server APIs (Orders and Payments).

## What is this Ruby project?

Both are for handling payments in Ruby/Rails applications. 

## What are the main difference between this Ruby project and similar ones?

Pay tries to provide a unified way to handle payments supporting different provides. PayPal Server SDK seems to be the official SDK from PayPal. We removed the predecessor in #1236.

---

Please help us to maintain this collection by using reactions (👍, 👎) and comments to express your feelings.
