### PR TITLE
Add awesome 🚦Stoplight to awesome-ruby list

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,6 +720,7 @@ Where to discover new Ruby libraries, projects and trends.
 * [Honeybadger](https://www.honeybadger.io/) - Exception, uptime, and performance monitoring for Ruby.
 * [Nesty](https://github.com/skorks/nesty) - Nested exceptions for Ruby.
 * [Sentry Ruby](https://github.com/getsentry/sentry-ruby) - The Ruby client for Sentry.
+* [Stoplight](https://github.com/bolshakov/stoplight) - A circuit breaker implementation for Ruby that prevents cascading failures when external dependencies (databases, APIs, third-party services) start failing.
 * [Rollbar](https://github.com/rollbar/rollbar-gem) - Easy and powerful exception and error tracking for your applications.
 
 ## Event Sourcing

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Thanks to all [contributors](https://github.com/markets/awesome-ruby/graphs/cont
 * [Light Service](https://github.com/adomokos/light-service) - Series of Actions with an emphasis on simplicity.
 * [Mutations](https://github.com/cypriss/mutations) - Compose your business logic into commands that sanitize and validate input.
 * [Servactory](https://github.com/servactory/servactory) - A set of tools for building reliable service objects of any complexity.
+* [Stoplight](https://github.com/bolshakov/stoplight) - A circuit breaker implementation for Ruby that prevents cascading failures when external dependencies (databases, APIs, third-party services) start failing.
 * [Surrounded](https://github.com/saturnflyer/surrounded) - Encapsulated related objects in a single system to add behavior during runtime. Extensible implementation of DCI.
 * [Waterfall](https://github.com/apneadiving/waterfall) - A slice of functional programming to chain ruby services and blocks, thus providing a new approach to flow control.
 * [wisper](https://github.com/krisleech/wisper) - A micro library providing Ruby objects with Publish-Subscribe capabilities.
@@ -720,7 +721,6 @@ Where to discover new Ruby libraries, projects and trends.
 * [Honeybadger](https://www.honeybadger.io/) - Exception, uptime, and performance monitoring for Ruby.
 * [Nesty](https://github.com/skorks/nesty) - Nested exceptions for Ruby.
 * [Sentry Ruby](https://github.com/getsentry/sentry-ruby) - The Ruby client for Sentry.
-* [Stoplight](https://github.com/bolshakov/stoplight) - A circuit breaker implementation for Ruby that prevents cascading failures when external dependencies (databases, APIs, third-party services) start failing.
 * [Rollbar](https://github.com/rollbar/rollbar-gem) - Easy and powerful exception and error tracking for your applications.
 
 ## Event Sourcing


### PR DESCRIPTION
## Project

RubyGems: https://rubygems.org/gems/stoplight (11M downloads)
GitHub: https://github.com/bolshakov/stoplight

## What is this Ruby project?

Stoplight is a circuit breaker implementation for Ruby that prevents cascading failures when external dependencies (databases, APIs, third-party services) start failing.

## What are the main differences between this project and similar ones?

There's no dedicated category for circuit breaker/fault tolerance libraries in this list yet, so I've added it under Error Handling. Please let me know if you'd prefer to move it somewhere else or create a new category.

Stoplight isn't really comparable to error-tracking tools like Bugsnag or Sentry. It solves a different problem (preventing failures vs. reporting them). The closest peer in the Ruby ecosystem is [Circuitbox](https://github.com/yammer/circuitbox). Both wrap calls to unreliable dependencies, but differ in a few notable ways:

- Stoplight computes error rates over a true sliding window in Redis, avoiding the boundary problem where a fixed window can under-count a burst of errors on the interval boundary. Circuitbox uses a tumbling window that resets every periodically - cheaper per request (just a counter increment), but with weaker guarantees at window boundaries.
- Circuitbox supports many backends via Moneta, Stoplight is Redis-first, with automatic failover to an in-memory store if Redis becomes unavailable.
- Stoplight ships a built-in admin dashboard for real-time monitoring and manual state overrides, Circuitbox relies on `ActiveSupport::Notifications` for observability.
- Stoplight is under active development, Circuitbox's last release was in 2023.

---

Please help us to maintain this collection by using reactions (👍, 👎) and comments to express your feelings.