### PR TITLE
Add ChatSDK — unified multi-platform chat bot SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1384,6 +1384,7 @@ Online tools, services and APIs to simplify development.
 ## Third-party APIs
 
 * [Ably](https://github.com/ably/ably-ruby) - Ruby library for realtime communication over Ably.
+* [ChatSDK](https://github.com/rootlyhq/chat-sdk) - Unified SDK for building chat bots across Slack, Teams, Google Chat, Discord, Telegram, Mattermost, Twilio, Messenger, and WhatsApp with a single API.
 * [discordrb](https://github.com/meew0/discordrb) - An implementation of the Discord API.
 * [Dropbox](https://github.com/Jesus/dropbox_api) - Ruby client for Dropbox API v2.
 * [fb_graph2](https://github.com/nov/fb_graph2) - A full-stack Facebook Graph API wrapper.


### PR DESCRIPTION
## Summary

- Add [ChatSDK](https://github.com/rootlyhq/chat-sdk) to the **Third-party APIs** section

## What is ChatSDK?

Unified Ruby SDK for building chat bots across 9 platforms (Slack, Teams, Google Chat, Discord, Telegram, Mattermost, Twilio, Messenger, WhatsApp) with a single normalized API. Write your bot logic once, deploy everywhere.

- 13 gems on RubyGems (`chat_sdk`, `chat_sdk-slack`, `chat_sdk-teams`, etc.)
- 708 specs, MIT licensed
- Cards DSL that renders as Block Kit / Adaptive Cards / Card V2 / embeds per platform
- Docs at [chat-sdk.ai](https://chat-sdk.ai)
- Built by [Rootly](https://rootly.com)